### PR TITLE
ci: GitHub Pagesへのデプロイと品質チェックを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Astro site to GitHub Pages
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build site
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -58,6 +54,9 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && 'pages-main' || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: ${{ github.ref == 'refs/heads/main' && 'pages-main' || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,9 +58,6 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
-    concurrency:
-      group: pages
-      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,4 +2,7 @@
 import { defineConfig } from "astro/config";
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: "https://t-ooshiro0125.github.io",
+  base: "/working-corgi",
+});

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint .",
-    "format": "prettier --write .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js package.json .prettierrc.json working-corgi.code-workspace",
-    "format:check": "prettier --check .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js package.json .prettierrc.json working-corgi.code-workspace"
+    "format": "prettier --write .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js package.json .prettierrc.json working-corgi.code-workspace .github",
+    "format:check": "prettier --check .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js package.json .prettierrc.json working-corgi.code-workspace .github"
   },
   "dependencies": {
     "astro": "^7.2.0"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,8 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href={`${import.meta.env.BASE_URL}/favicon.svg`}
+    />
+    <link rel="icon" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
     <meta name="generator" content={Astro.generator} />
     <title>Astro Basics</title>
   </head>


### PR DESCRIPTION
## 関連 Issue

Closes #1

## 変更内容

- PR では整形・Lint・ビルドを実行し、`main` への push 時には GitHub Pages へデプロイする workflow を追加
- Astro の `site` と `base` を GitHub Pages の公開URLに設定
- リポジトリ配下で favicon が正しく読み込まれるようパスを修正
- `.github` を Prettier の整形対象に追加

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認