### PR TITLE
chore: setup-nodeをNode.js 24対応版へ更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## 関連 Issue

Closes #4

## 変更内容

- `actions/setup-node` を `v4` から Node.js 24 対応の `v7` へ更新

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`
- PR 上の GitHub Actions で Node.js 20 廃止警告が解消されることを確認予定

## チェックリスト

- [x] 関連 Issue のリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [ ] ブラウザで表示を確認（表示変更なし）
- [x] 関連ドキュメントの更新要否を確認