### PR TITLE
docs: GitHub Pagesの初回設定手順を追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -32,5 +32,16 @@
 
 ## 公開
 
-- GitHub Pages の設定は GitHub Actions で管理する。
+### 初回設定
+
+- GitHub Pages のデプロイは GitHub Actions で管理する。
+- 初回の Pages デプロイ前に、GitHub の **Settings → Pages → Build and deployment → Source** を **GitHub Actions** に一度だけ設定する。
+
+### デプロイと確認
+
 - 公開前に本番ビルドを確認し、リンク、画像、サイトのベースパスが GitHub Pages 上でも正しいことを確認する。
+- 公開後は、GitHub Pages の公開 URL でサイトと静的アセットが表示されることを確認する。
+
+### トラブルシューティング
+
+- `actions/configure-pages` が Pages サイトを取得できず失敗した場合は、この公開元設定を確認してから、失敗した workflow を再実行するか次回の `main` push を待つ。


### PR DESCRIPTION
## 関連 Issue

Closes #5

## 変更内容

- GitHub Pages の公開手順を「初回設定」「デプロイと確認」「トラブルシューティング」に整理
- Pages の公開元を GitHub Actions に設定する初回手順を追加
- `configure-pages` 失敗時の復旧方法と、公開後の確認項目を追加

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [ ] ブラウザで表示を確認（ドキュメント変更のみ）
- [x] 関連ドキュメントの更新要否を確認