### PR TITLE
docs: ブランチとPull Requestの開発フローを追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,50 @@
   git diff --cached
   ```
 
+## ブランチと Pull Request
+
+- `main` への直接 push はしない。Issue に対応する変更はブランチで行い、Pull Request を通して `main` へマージする。
+- 新しい作業を始める前に、現在の作業ツリーがクリーンであることを確認する。未コミットの変更がある場合は、対応中の作業としてコミットするか、安全に退避してから切り替える。
+
+### 命名規則
+
+| 作業                     | ブランチ名                      | 例                     |
+| ------------------------ | ------------------------------- | ---------------------- |
+| Issue に対応する変更     | `<種類>/<Issue番号>-<短い説明>` | `feat/10-about-page`   |
+| Issue を作らない文書変更 | `docs/<短い説明>`               | `docs/branch-workflow` |
+
+- `<種類>` にはコミットメッセージと同じ `feat`、`fix`、`docs`、`chore`、`refactor`、`test`、`ci` を使う。
+
+### 新しい Issue に着手する手順
+
+```sh
+# 現在の変更がないことを確認する
+git status --short
+
+# main を最新化する
+git switch main
+git pull --ff-only origin main
+
+# Issue 用の作業ブランチを作成する
+git switch -c <種類>/<Issue番号>-<短い説明>
+```
+
+### Push と Pull Request
+
+実装とローカル検証が完了したら、変更をコミットしてから次を実行する。
+
+```sh
+# 初回だけ。現在のブランチを push し、リモート追跡ブランチを設定する
+git push -u origin HEAD
+
+# 2回目以降
+git push
+```
+
+- `HEAD` は現在チェックアウトしているブランチを指す。ブランチ名を手入力する必要がなく、入力ミスを防げる。
+- push 後、`main` 宛ての Pull Request を作成する。
+- CI の成功とレビュー完了後、GitHub 上で squash merge する。
+
 ## 公開
 
 ### 初回設定

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,7 @@
 | Issue に対応する変更     | `<種類>/<Issue番号>-<短い説明>` | `feat/10-about-page`   |
 | Issue を作らない文書変更 | `docs/<短い説明>`               | `docs/branch-workflow` |
 
-- `<種類>` にはコミットメッセージと同じ `feat`、`fix`、`docs`、`chore`、`refactor`、`test`、`ci` を使う。
+- `<種類>` には、[コミットメッセージ](conventions.md#コミットメッセージ)で定めた種類を使う。
 
 ### 新しい Issue に着手する手順
 


### PR DESCRIPTION
## 関連 Issue

- なし

## 変更内容

- `main` から作業ブランチを切る手順を追加
- Issue の有無に応じたブランチ命名規則を追加
- 初回・2回目以降の push 手順と、PR・squash merge の流れを追加

## 確認内容

- `npm run format:check`
- `git diff --check`

## チェックリスト

- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] 関連ドキュメントの更新要否を確認
- [ ] `npm run lint`、`npm run build` を実行
- [ ] ブラウザで表示を確認（文書変更のみのため不要）