### PR TITLE
feat: Aboutページとサイトナビゲーションを追加

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,11 @@ interface Props {
 
 const { title = "Working Corgi", description = "Corgi の個人サイトです。" } =
   Astro.props;
+
+const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
+const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
+const isHome = currentPath === basePath;
+const isAbout = currentPath === `${basePath}/about`;
 ---
 
 <!doctype html>
@@ -18,9 +23,9 @@ const { title = "Working Corgi", description = "Corgi の個人サイトです�
     <link
       rel="icon"
       type="image/svg+xml"
-      href={`${import.meta.env.BASE_URL}favicon.svg`}
+      href={`${import.meta.env.BASE_URL}/favicon.svg`}
     />
-    <link rel="icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />
+    <link rel="icon" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -32,6 +37,22 @@ const { title = "Working Corgi", description = "Corgi の個人サイトです�
           <a class="site-header__name" href={import.meta.env.BASE_URL}>
             Working Corgi
           </a>
+          <nav class="site-header__nav" aria-label="メインナビゲーション">
+            <a
+              class="site-header__link"
+              href={import.meta.env.BASE_URL}
+              aria-current={isHome ? "page" : undefined}
+            >
+              Home
+            </a>
+            <a
+              class="site-header__link"
+              href={`${import.meta.env.BASE_URL}/about/`}
+              aria-current={isAbout ? "page" : undefined}
+            >
+              About
+            </a>
+          </nav>
         </div>
       </header>
 
@@ -61,6 +82,10 @@ const { title = "Working Corgi", description = "Corgi の個人サイトです�
     }
 
     .site-header__inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-md);
       width: 100%;
       max-width: var(--content-width);
       margin-inline: auto;
@@ -72,6 +97,32 @@ const { title = "Working Corgi", description = "Corgi の個人サイトです�
       font-size: 1rem;
       font-weight: 700;
       letter-spacing: 0.04em;
+    }
+
+    .site-header__nav {
+      display: flex;
+      gap: var(--space-sm);
+    }
+
+    .site-header__link {
+      display: inline-flex;
+      align-items: center;
+      min-height: 2.25rem;
+      padding-inline: var(--space-sm);
+      color: var(--color-text-muted);
+      border-radius: var(--radius-sm);
+      font-size: 0.875rem;
+      font-weight: 700;
+
+      &:hover {
+        color: var(--color-text);
+        background: var(--color-accent-soft);
+      }
+    }
+
+    .site-header__link[aria-current="page"] {
+      color: var(--color-text);
+      background: var(--color-accent-soft);
     }
 
     .site-main {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,95 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout
+  title="About | Working Corgi"
+  description="Corgi の経歴、得意分野、現在取り組んでいることを紹介します。"
+>
+  <div class="about">
+    <section class="about__hero">
+      <h1 class="about__title">About</h1>
+      <p class="about__lead">Corgi について、もう少し詳しく。</p>
+    </section>
+
+    <section class="about__section">
+      <h2 class="about__heading">プロフィール</h2>
+      <p>
+        仕事ではWebエンジニアをしています。なんだかんだRailsを10年くらい触っていますが、今でも分からないことだらけです。最近は個人開発が楽しくて、欲しいものや思いついたものを好き勝手作っています（まだ何も完成していませんが）。
+      </p>
+      <p>
+        器用貧乏気味で、気になったところをあれこれ触りがちです。仕組みを理解するのが好きで、分からないままだと少しイライラします。
+      </p>
+      <p>仕事も個人開発も、AIに助けてもらいながらぼちぼちやっています。</p>
+    </section>
+
+    <section class="about__section">
+      <h2 class="about__heading">できること</h2>
+      <dl class="about__skills">
+        <div class="about__skill">
+          <dt class="about__skill-name">Web開発</dt>
+          <dd>新規開発、既存機能の改修・保守、日々の小さな改善。</dd>
+        </div>
+        <div class="about__skill">
+          <dt class="about__skill-name">Rails</dt>
+          <dd>
+            Railsは気づけば10年ほど。バックエンドを中心に、フロントエンドからインフラまで幅広く触ってきました。器用貧乏です。
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="about__section">
+      <h2 class="about__heading">今取り組んでいること</h2>
+      <p>
+        個人開発では、キャラクターと会話するアプリと、この個人サイトを作っています。
+      </p>
+    </section>
+
+    <section class="about__section">
+      <h2 class="about__heading">好きなこと</h2>
+      <p>トモダチコレクションをのんびり遊んでいます。</p>
+      <p>
+        最近はVTuberの配信をよく観ます。ぺこーら、あずきち、おかゆんあたり。
+      </p>
+    </section>
+  </div>
+</Layout>
+
+<style lang="scss">
+  .about {
+    display: grid;
+    gap: var(--space-2xl);
+  }
+
+  .about__hero {
+    padding-block: var(--space-2xl);
+  }
+
+  .about__section {
+    padding-top: var(--space-xl);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .about__heading {
+    margin-bottom: var(--space-md);
+    font-size: 1.25rem;
+  }
+
+  .about__skills {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .about__skill {
+    padding: var(--space-md);
+    background: var(--color-accent-soft);
+    border-radius: var(--radius-sm);
+  }
+
+  .about__skill-name {
+    margin-bottom: var(--space-xs);
+    color: var(--color-accent-strong);
+    font-weight: 700;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,9 @@ import Layout from "../layouts/Layout.astro";
       <p>
         コミュニケーションを取るのが苦手ですが、嫌いではないです。下手なだけです。よろしくお願いします。
       </p>
+      <a class="home__more-link" href={`${import.meta.env.BASE_URL}/about/`}>
+        About を見る
+      </a>
     </section>
 
     <section class="home__section">
@@ -123,6 +126,25 @@ import Layout from "../layouts/Layout.astro";
       color: var(--color-surface);
       background: var(--color-accent-strong);
       transform: translateY(-0.125rem);
+    }
+  }
+
+  .home__more-link {
+    display: inline-flex;
+    align-items: center;
+    margin-top: var(--space-md);
+    color: var(--color-accent-strong);
+    font-size: 0.875rem;
+    font-weight: 700;
+
+    &::after {
+      margin-left: var(--space-xs);
+      content: "→";
+      transition: transform 160ms ease;
+    }
+
+    &:hover::after {
+      transform: translateX(0.25rem);
     }
   }
 </style>


### PR DESCRIPTION
## 関連 Issue

- Close #10

<!-- develop 宛ての PR は Issue を自動クローズしない。右側の Development から Issue を手動でリンクする。 -->

## 変更内容

- `/about/` にプロフィールページを追加
- ヘッダーに Home / About のナビゲーションを追加
- 現在ページを `aria-current="page"` で示し、見た目も切り替えるようにした
- Home の自己紹介カードから About へのリンクを追加
- GitHub Pages 配下でも favicon を読み込めるパスに修正

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`

## チェックリスト

- [x] 関連 Issue とのリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] テスト・動作確認
- [x] 関連ドキュメントの更新要否確認