### PR TITLE
feat: 独自ドメインとXリンクを設定

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,5 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://t-ooshiro0125.github.io",
-  base: "/working-corgi",
+  site: "https://workingcorgi.com",
 });

--- a/docs/product.md
+++ b/docs/product.md
@@ -41,7 +41,7 @@
 ### 外部リンク
 
 - GitHub: https://github.com/t-ooshiro0125
-- SNS: （掲載しない）
+- SNS: https://x.com/working_corgi
 - その他: （掲載しない）
 
 ## コンテンツの方針

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,10 +11,20 @@ const {
   description = "ACorgi0125 の個人サイトです。",
 } = Astro.props;
 
-const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
 const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
-const isHome = currentPath === basePath;
-const isAbout = currentPath === `${basePath}/about`;
+
+const navigation = [
+  { label: "Home", href: import.meta.env.BASE_URL },
+  { label: "About", href: `${import.meta.env.BASE_URL}about/` },
+].map((item) => {
+  const path =
+    new URL(item.href, Astro.url).pathname.replace(/\/+$/, "") || "/";
+
+  return {
+    ...item,
+    isCurrent: currentPath === path,
+  };
+});
 ---
 
 <!doctype html>
@@ -25,13 +35,13 @@ const isAbout = currentPath === `${basePath}/about`;
     <link
       rel="icon"
       type="image/png"
-      href={`${import.meta.env.BASE_URL}/corgi-favicon-black.png`}
+      href={`${import.meta.env.BASE_URL}corgi-favicon-black.png`}
       media="(prefers-color-scheme: light)"
     />
     <link
       rel="icon"
       type="image/png"
-      href={`${import.meta.env.BASE_URL}/corgi-favicon-white.png`}
+      href={`${import.meta.env.BASE_URL}corgi-favicon-white.png`}
       media="(prefers-color-scheme: dark)"
     />
     <meta name="generator" content={Astro.generator} />
@@ -42,7 +52,7 @@ const isAbout = currentPath === `${basePath}/about`;
     <div class="site">
       <img
         class="site__paw-prints"
-        src={`${import.meta.env.BASE_URL}/corgi-paw-prints.svg`}
+        src={`${import.meta.env.BASE_URL}corgi-paw-prints.svg`}
         alt=""
       />
 
@@ -55,7 +65,7 @@ const isAbout = currentPath === `${basePath}/about`;
           >
             <img
               class="site-header__logo"
-              src={`${import.meta.env.BASE_URL}/corgi-favicon-black.webp`}
+              src={`${import.meta.env.BASE_URL}corgi-favicon-black.webp`}
               alt=""
               width="512"
               height="512"
@@ -63,20 +73,17 @@ const isAbout = currentPath === `${basePath}/about`;
             <span class="site-header__name">Working Corgi</span>
           </a>
           <nav class="site-header__nav" aria-label="メインナビゲーション">
-            <a
-              class="site-header__link"
-              href={import.meta.env.BASE_URL}
-              aria-current={isHome ? "page" : undefined}
-            >
-              Home
-            </a>
-            <a
-              class="site-header__link"
-              href={`${import.meta.env.BASE_URL}/about/`}
-              aria-current={isAbout ? "page" : undefined}
-            >
-              About
-            </a>
+            {
+              navigation.map(({ label, href, isCurrent }) => (
+                <a
+                  class="site-header__link"
+                  href={href}
+                  aria-current={isCurrent ? "page" : undefined}
+                >
+                  {label}
+                </a>
+              ))
+            }
           </nav>
         </div>
       </header>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import Layout from "../layouts/Layout.astro";
 
       <img
         class="about__avatar"
-        src={`${import.meta.env.BASE_URL}/corgi-avatar-calm.webp`}
+        src={`${import.meta.env.BASE_URL}corgi-avatar-calm.webp`}
         alt=""
         width="1536"
         height="1024"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import Layout from "../layouts/Layout.astro";
 
       <img
         class="home__hero-image"
-        src={`${import.meta.env.BASE_URL}/corgi-hero.webp`}
+        src={`${import.meta.env.BASE_URL}corgi-hero.webp`}
         alt="ノートパソコンで作業するコーギーのイラスト"
         width="1536"
         height="1024"
@@ -28,7 +28,7 @@ import Layout from "../layouts/Layout.astro";
       <p>
         Web開発を中心に仕事をしながら、個人でもアプリやこのサイトを作っています。
       </p>
-      <a class="home__more-link" href={`${import.meta.env.BASE_URL}/about/`}>
+      <a class="home__more-link" href={`${import.meta.env.BASE_URL}about/`}>
         About を見る
       </a>
     </section>
@@ -53,9 +53,19 @@ import Layout from "../layouts/Layout.astro";
             class="home__link"
             href="https://github.com/t-ooshiro0125"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             GitHub
+          </a>
+        </li>
+        <li>
+          <a
+            class="home__link"
+            href="https://x.com/working_corgi"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            X
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## 関連 Issue

- Closes #16

## 変更内容

- Astro の公開 URL を `https://workingcorgi.com` に変更し、GitHub Pages 用の `base` 設定を削除
- 独自ドメイン配下で画像・favicon・ページ遷移が正しく動くよう、`BASE_URL` を使うパスを修正
- ナビゲーションを配列で管理し、現在ページの `aria-current` を正しく設定
- Home に X アカウントへのリンクを追加
- `docs/product.md` の外部リンク情報を更新

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`
- ローカルで Home / About の表示、画像、ナビゲーション、現在ページ表示を確認

## チェックリスト

- [x] 関連 Issue とのリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] テスト・動作確認
- [x] 関連ドキュメントの更新要否確認