### PR TITLE
feat: Contact ページを追加

### DIFF
--- a/src/components/ExternalLinkIcon.astro
+++ b/src/components/ExternalLinkIcon.astro
@@ -1,0 +1,20 @@
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 3h7v7"></path>
+  <path d="m21 3-9 9"></path>
+  <path d="M19 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h5"></path>
+</svg>
+
+<style>
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,10 @@
+export const profiles = {
+  github: {
+    url: "https://github.com/t-ooshiro0125",
+    handle: "t-ooshiro0125",
+  },
+  x: {
+    url: "https://x.com/working_corgi",
+    handle: "@working_corgi",
+  },
+} as const;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -166,7 +166,8 @@ const navigation = navigationItems.map((item) => {
       justify-content: space-between;
       width: 100%;
       max-width: var(--content-width);
-      padding: var(--space-lg) var(--content-padding);
+      padding: var(--space-lg)
+        clamp(var(--space-md), 3vw, var(--content-padding));
       margin-inline: auto;
     }
 
@@ -192,14 +193,14 @@ const navigation = navigationItems.map((item) => {
 
     .site-header__nav {
       display: flex;
-      gap: var(--space-sm);
+      gap: clamp(var(--space-2xs), 1.5vw, var(--space-sm));
     }
 
     .site-header__link {
       display: inline-flex;
       align-items: center;
       min-height: 2.25rem;
-      padding-inline: var(--space-sm);
+      padding-inline: clamp(var(--space-2xs), 1.5vw, var(--space-sm));
       font-size: 0.875rem;
       font-weight: 700;
       color: var(--color-text-muted);
@@ -243,24 +244,28 @@ const navigation = navigationItems.map((item) => {
       color: var(--color-text-muted);
     }
 
-    @media (width <= 35rem) {
+    @media (width <= 40rem) {
       .site-header__inner {
-        gap: var(--space-sm);
-        padding-inline: var(--space-md);
+        flex-wrap: wrap;
+        row-gap: var(--space-sm);
       }
 
       .site-header__nav {
-        gap: 0;
-      }
-
-      .site-header__link {
-        padding-inline: var(--space-xs);
+        flex-wrap: wrap;
+        justify-content: center;
+        width: 100%;
       }
     }
 
-    @media (width <= 30rem) {
-      .site-header__name {
-        display: none;
+    @media (width <= 24rem) {
+      .site-header__nav {
+        flex-wrap: nowrap;
+        gap: var(--space-2xs);
+      }
+
+      .site-header__link {
+        padding-inline: var(--space-2xs);
+        font-size: 0.75rem;
       }
     }
   </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const navigationItems = [
   { label: "About", href: `${baseUrl}about/` },
   { label: "Works", href: `${baseUrl}works/` },
   { label: "Notes", href: `${baseUrl}notes/` },
+  { label: "Contact", href: `${baseUrl}contact/` },
 ];
 
 const {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,125 @@
+---
+import Layout from "../layouts/Layout.astro";
+import ExternalLinkIcon from "../components/ExternalLinkIcon.astro";
+import { profiles } from "../config/site";
+
+const contactMethods = [
+  {
+    service: "X",
+    description: `${profiles.x.handle} へ DM する`,
+    href: profiles.x.url,
+    ariaLabel: "X のプロフィールを新しいタブで開く（外部サイト）",
+  },
+  {
+    service: "GitHub",
+    description: `${profiles.github.handle} のプロフィールを見る`,
+    href: profiles.github.url,
+    ariaLabel: "GitHub プロフィールを新しいタブで開く（外部サイト）",
+  },
+];
+---
+
+<Layout
+  title="Contact | Working Corgi"
+  description="ACorgi0125 への連絡方法を案内します。"
+>
+  <div class="contact">
+    <section class="contact__hero">
+      <p class="page__eyebrow">GET IN TOUCH</p>
+      <h1 class="page__title">Contact</h1>
+      <p class="page__lead">
+        ご連絡は、X の DM または GitHub プロフィールからお願いします。
+      </p>
+    </section>
+
+    <section class="contact__methods" aria-labelledby="contact-methods-title">
+      <h2 id="contact-methods-title" class="contact__heading">連絡先</h2>
+
+      <ul class="contact__list" role="list">
+        {
+          contactMethods.map(({ service, description, href, ariaLabel }) => (
+            <li>
+              <a
+                class="contact__link"
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={ariaLabel}
+              >
+                <span class="contact__service">{service}</span>
+                <span class="contact__description">{description}</span>
+                <span class="contact__external" aria-hidden="true">
+                  <ExternalLinkIcon />
+                </span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </div>
+</Layout>
+
+<style lang="scss">
+  .contact {
+    display: grid;
+    gap: var(--space-2xl);
+  }
+
+  .contact__hero {
+    max-width: 42rem;
+    padding-block: var(--space-2xl);
+  }
+
+  .contact__heading {
+    margin-bottom: var(--space-md);
+    font-size: 1.25rem;
+  }
+
+  .contact__list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: 0;
+  }
+
+  .contact__link {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-2xs);
+    align-items: center;
+    padding: var(--space-lg);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 0.25rem solid var(--color-sage);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    transition:
+      background-color 0.2s,
+      transform 0.2s;
+
+    &:hover {
+      background: var(--color-accent-soft);
+      transform: translateY(-0.125rem);
+    }
+  }
+
+  .contact__service {
+    font-weight: 700;
+  }
+
+  .contact__description {
+    grid-column: 1;
+    color: var(--color-text-muted);
+  }
+
+  .contact__external {
+    display: block;
+    grid-row: 1 / span 2;
+    grid-column: 2;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--color-accent-strong);
+  }
+</style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,13 +8,11 @@ const contactMethods = [
     service: "X",
     description: `${profiles.x.handle} へ DM する`,
     href: profiles.x.url,
-    ariaLabel: "X のプロフィールを新しいタブで開く（外部サイト）",
   },
   {
     service: "GitHub",
     description: `${profiles.github.handle} のプロフィールを見る`,
     href: profiles.github.url,
-    ariaLabel: "GitHub プロフィールを新しいタブで開く（外部サイト）",
   },
 ];
 ---
@@ -37,17 +35,17 @@ const contactMethods = [
 
       <ul class="contact__list" role="list">
         {
-          contactMethods.map(({ service, description, href, ariaLabel }) => (
+          contactMethods.map(({ service, description, href }) => (
             <li>
               <a
                 class="contact__link"
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label={ariaLabel}
               >
                 <span class="contact__service">{service}</span>
                 <span class="contact__description">{description}</span>
+                <span class="contact__new-tab">新しいタブで開く</span>
                 <span class="contact__external" aria-hidden="true">
                   <ExternalLinkIcon />
                 </span>
@@ -112,6 +110,18 @@ const contactMethods = [
   .contact__description {
     grid-column: 1;
     color: var(--color-text-muted);
+  }
+
+  .contact__new-tab {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    white-space: nowrap;
+    border: 0;
+    clip-path: inset(50%);
   }
 
   .contact__external {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -92,7 +92,7 @@ const contactMethods = [
     color: var(--color-text);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-left: 0.25rem solid var(--color-sage);
+    border-left: 0.25rem solid var(--color-accent);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-soft);
     transition:

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { profiles } from "../config/site";
 ---
 
 <Layout
@@ -60,7 +61,7 @@ import Layout from "../layouts/Layout.astro";
         <li>
           <a
             class="home__link button"
-            href="https://github.com/t-ooshiro0125"
+            href={profiles.github.url}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -70,7 +71,7 @@ import Layout from "../layouts/Layout.astro";
         <li>
           <a
             class="home__link button"
-            href="https://x.com/working_corgi"
+            href={profiles.x.url}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## 関連 Issue

Closes #24

## 変更内容

- X の DM と GitHub プロフィールへ遷移できる Contact ページを追加
- 共通ナビゲーションから Contact ページへ移動できるように変更
- 外部リンクを新しいタブで開き、アクセシビリティ用ラベルと外部リンクアイコンを追加
- 外部プロフィールの URL とハンドルを `src/config/site.ts` に一元化し、Home と Contact で参照

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認