### PR TITLE
feat: フッターにサイト案内と外部リンクを追加

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,213 @@
+---
+import ExternalLinkIcon from "./ExternalLinkIcon.astro";
+import { navigationItems, profileItems } from "../config/site";
+
+interface Props {
+  baseUrl: string;
+}
+
+const { baseUrl } = Astro.props as Props;
+---
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <a
+        class="site-footer__brand-link"
+        href={baseUrl}
+        aria-label="Working Corgi"
+      >
+        <img
+          class="site-footer__brand-mark"
+          src={`${baseUrl}corgi-mark.webp`}
+          alt=""
+          width="56"
+          height="56"
+        />
+        <span class="site-footer__brand-name">Working Corgi</span>
+      </a>
+      <p class="site-footer__description">
+        Web開発を中心に仕事をしながら、<br
+          class="site-footer__description-break"
+        />個人でもアプリやこのサイトを作っています。
+      </p>
+    </div>
+
+    <nav class="site-footer__nav" aria-label="サイト案内">
+      <p class="site-footer__heading">Site</p>
+      <ul class="site-footer__links" role="list">
+        {
+          navigationItems.map(({ label, path }) => (
+            <li>
+              <a class="site-footer__link" href={`${baseUrl}${path}`}>
+                {label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+
+    <nav class="site-footer__nav" aria-label="外部プロフィール">
+      <p class="site-footer__heading">Profile</p>
+      <ul class="site-footer__links" role="list">
+        {
+          profileItems.map(({ label, url, handle }) => (
+            <li>
+              <a class="site-footer__link" href={url}>
+                <span>{label}</span>
+                <span class="site-footer__handle">{handle}</span>
+                <span class="site-footer__external" aria-hidden="true">
+                  <ExternalLinkIcon />
+                </span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+
+    <p class="site-footer__copyright">
+      © {new Date().getFullYear()} Working Corgi
+    </p>
+  </div>
+</footer>
+
+<style lang="scss">
+  .site-footer {
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .site-footer__inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) repeat(2, minmax(0, 1fr));
+    gap: var(--space-lg) var(--space-2xl);
+    width: 100%;
+    max-width: var(--content-width);
+    padding: var(--space-xl) var(--content-padding) var(--space-lg);
+    margin-inline: auto;
+  }
+
+  .site-footer__brand {
+    align-self: center;
+  }
+
+  .site-footer__brand-link {
+    display: inline-flex;
+    gap: var(--space-xs);
+    align-items: center;
+    color: var(--color-text);
+  }
+
+  .site-footer__brand-mark {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+
+  .site-footer__brand-name {
+    font-weight: 700;
+  }
+
+  .site-footer__description {
+    margin-top: var(--space-xs);
+    font-size: 0.875rem;
+  }
+
+  .site-footer__description-break {
+    display: block;
+  }
+
+  .site-footer__heading {
+    margin-bottom: var(--space-xs);
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--color-accent-strong);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .site-footer__nav {
+    padding-left: var(--space-xl);
+    border-left: 1px solid var(--color-border);
+  }
+
+  .site-footer__links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs) var(--space-sm);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .site-footer__link {
+    display: inline-flex;
+    gap: var(--space-2xs);
+    align-items: center;
+    min-height: 2.25rem;
+    padding-inline: var(--space-2xs);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    text-decoration-line: underline;
+    text-decoration-thickness: 0.08em;
+    text-decoration-color: transparent;
+    text-underline-offset: 0.16em;
+    transition:
+      color 160ms ease,
+      text-decoration-color 160ms ease;
+
+    &:hover {
+      color: var(--color-text);
+      text-decoration-color: currentcolor;
+    }
+  }
+
+  .site-footer__handle {
+    color: var(--color-text-muted);
+  }
+
+  .site-footer__external {
+    display: block;
+    flex: 0 0 auto;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .site-footer__copyright {
+    grid-column: 1 / -1;
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  @media (width <= 52rem) {
+    .site-footer__inner {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .site-footer__brand {
+      grid-column: 1 / -1;
+    }
+
+    .site-footer__nav {
+      padding-left: 0;
+      border-left: 0;
+    }
+  }
+
+  @media (width <= 40rem) {
+    .site-footer__inner {
+      grid-template-columns: 1fr;
+      gap: var(--space-lg);
+      padding-block: var(--space-lg);
+    }
+
+    .site-footer__copyright {
+      grid-column: auto;
+      justify-self: center;
+      text-align: center;
+    }
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,28 +1,23 @@
 ---
+import { navigationItems } from "../config/site";
+
 interface Props {
   baseUrl: string;
 }
 
 const { baseUrl } = Astro.props as Props;
 
-const navigationItems = [
-  { label: "Home", href: baseUrl },
-  { label: "About", href: `${baseUrl}about/` },
-  { label: "Works", href: `${baseUrl}works/` },
-  { label: "Notes", href: `${baseUrl}notes/` },
-  { label: "Contact", href: `${baseUrl}contact/` },
-];
-
 const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
-const navigation = navigationItems.map((item) => {
-  const path =
-    new URL(item.href, Astro.url).pathname.replace(/\/+$/, "") || "/";
+const navigation = navigationItems.map(({ label, path }) => {
+  const href = `${baseUrl}${path}`;
+  const pathname = new URL(href, Astro.url).pathname.replace(/\/+$/, "") || "/";
 
   return {
-    ...item,
+    label,
+    href,
     isCurrent:
-      currentPath === path ||
-      (path !== "/" && currentPath.startsWith(`${path}/`)),
+      currentPath === pathname ||
+      (pathname !== "/" && currentPath.startsWith(`${pathname}/`)),
   };
 });
 ---

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,10 +1,22 @@
 export const profiles = {
   github: {
+    label: "GitHub",
     url: "https://github.com/t-ooshiro0125",
     handle: "t-ooshiro0125",
   },
   x: {
+    label: "X",
     url: "https://x.com/working_corgi",
     handle: "@working_corgi",
   },
 } as const;
+
+export const profileItems = [profiles.github, profiles.x] as const;
+
+export const navigationItems = [
+  { label: "Home", path: "" },
+  { label: "About", path: "about/" },
+  { label: "Works", path: "works/" },
+  { label: "Notes", path: "notes/" },
+  { label: "Contact", path: "contact/" },
+] as const;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import "../styles/index.scss";
 
@@ -78,13 +79,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
         <slot />
       </main>
 
-      <footer class="site-footer">
-        <div class="site-footer__inner">
-          <p class="site-footer__copyright">
-            © {new Date().getFullYear()} Working Corgi
-          </p>
-        </div>
-      </footer>
+      <Footer baseUrl={baseUrl} />
     </div>
   </body>
 
@@ -113,24 +108,6 @@ const ogImageURL = new URL(ogImage, Astro.site);
       max-width: var(--content-width);
       padding: var(--space-2xl) var(--content-padding);
       margin-inline: auto;
-    }
-
-    .site-footer {
-      position: relative;
-      z-index: 1;
-      border-top: 1px solid var(--color-border);
-    }
-
-    .site-footer__inner {
-      width: 100%;
-      max-width: var(--content-width);
-      padding: var(--space-lg) var(--content-padding);
-      margin-inline: auto;
-    }
-
-    .site-footer__copyright {
-      font-size: 0.875rem;
-      color: var(--color-text-muted);
     }
   </style>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,12 +5,12 @@ import { profiles } from "../config/site";
 
 const contactMethods = [
   {
-    service: "X",
+    service: profiles.x.label,
     description: `${profiles.x.handle} へ DM する`,
     href: profiles.x.url,
   },
   {
-    service: "GitHub",
+    service: profiles.github.label,
     description: `${profiles.github.handle} のプロフィールを見る`,
     href: profiles.github.url,
   },
@@ -45,7 +45,7 @@ const contactMethods = [
               >
                 <span class="contact__service">{service}</span>
                 <span class="contact__description">{description}</span>
-                <span class="contact__new-tab">新しいタブで開く</span>
+                <span class="visually-hidden">新しいタブで開く</span>
                 <span class="contact__external" aria-hidden="true">
                   <ExternalLinkIcon />
                 </span>
@@ -110,18 +110,6 @@ const contactMethods = [
   .contact__description {
     grid-column: 1;
     color: var(--color-text-muted);
-  }
-
-  .contact__new-tab {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    white-space: nowrap;
-    border: 0;
-    clip-path: inset(50%);
   }
 
   .contact__external {

--- a/src/styles/foundation/_base.scss
+++ b/src/styles/foundation/_base.scss
@@ -36,6 +36,18 @@ p {
   text-wrap: pretty;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip-path: inset(50%);
+}
+
 a {
   border-radius: var(--radius-sm);
   transition:


### PR DESCRIPTION
## 関連 Issue

Closes #35

## 変更内容

- サイト案内、外部プロフィール、コピーライトを表示する共通フッターを追加
- ヘッダーとフッターのナビゲーション定義を `src/config/site.ts` に集約
- GitHub・Xの表示名、URL、ハンドルを共通設定から参照
- 画面幅に応じてレイアウトが切り替わるレスポンシブスタイルを追加
- `visually-hidden` を共通スタイルへ移動し、Contactページでも利用

## 確認内容

- `npm run format:check` 成功
- `npm run lint` 成功
- `npm run build` 成功

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認