### PR TITLE
refactor: サイト名と既定メタデータを共通設定に集約 (#45)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import ExternalLinkIcon from "./ExternalLinkIcon.astro";
-import { navigationItems, profileItems } from "../config/site";
+import { navigationItems, profileItems, site } from "../config/site";
 
 interface Props {
   baseUrl: string;
@@ -12,11 +12,7 @@ const { baseUrl } = Astro.props as Props;
 <footer class="site-footer">
   <div class="site-footer__inner">
     <div class="site-footer__brand">
-      <a
-        class="site-footer__brand-link"
-        href={baseUrl}
-        aria-label="Working Corgi"
-      >
+      <a class="site-footer__brand-link" href={baseUrl} aria-label={site.name}>
         <img
           class="site-footer__brand-mark"
           src={`${baseUrl}corgi-mark.webp`}
@@ -24,7 +20,7 @@ const { baseUrl } = Astro.props as Props;
           width="56"
           height="56"
         />
-        <span class="site-footer__brand-name">Working Corgi</span>
+        <span class="site-footer__brand-name">{site.name}</span>
       </a>
       <p class="site-footer__description">
         Web開発を中心に仕事をしながら、<br
@@ -68,7 +64,7 @@ const { baseUrl } = Astro.props as Props;
     </nav>
 
     <p class="site-footer__copyright">
-      © {new Date().getFullYear()} Working Corgi
+      © {new Date().getFullYear()}{" "}{site.name}
     </p>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { navigationItems } from "../config/site";
+import { navigationItems, site } from "../config/site";
 
 interface Props {
   baseUrl: string;
@@ -24,7 +24,7 @@ const navigation = navigationItems.map(({ label, path }) => {
 
 <header class="site-header">
   <div class="site-header__inner">
-    <a class="site-header__brand" href={baseUrl} aria-label="Working Corgi">
+    <a class="site-header__brand" href={baseUrl} aria-label={site.name}>
       <img
         class="site-header__logo"
         src={`${baseUrl}corgi-mark.webp`}
@@ -32,7 +32,7 @@ const navigation = navigationItems.map(({ label, path }) => {
         width="56"
         height="56"
       />
-      <span class="site-header__name">Working Corgi</span>
+      <span class="site-header__name">{site.name}</span>
     </a>
     <button
       class="site-header__menu-button"

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,3 +1,14 @@
+const siteName = "Working Corgi";
+
+export const site = {
+  name: siteName,
+  defaultDescription: "ACorgi0125 の個人サイトです。",
+  defaultOgp: {
+    image: "/og-image.png",
+    imageAlt: `${siteName} のロゴと、キャップをかぶったコーギーのイラスト`,
+  },
+} as const;
+
 export const profiles = {
   github: {
     label: "GitHub",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
+import { site } from "../config/site";
 import "../styles/index.scss";
 
 interface Props {
@@ -14,10 +15,10 @@ interface Props {
 const baseUrl = import.meta.env.BASE_URL;
 
 const {
-  title = "Working Corgi",
-  description = "ACorgi0125 の個人サイトです。",
-  ogImage = "/og-image.png",
-  ogImageAlt = "Working Corgi のロゴと、キャップをかぶったコーギーのイラスト",
+  title = site.name,
+  description = site.defaultDescription,
+  ogImage = site.defaultOgp.image,
+  ogImageAlt = site.defaultOgp.imageAlt,
   noindex = false,
 } = Astro.props as Props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -54,7 +55,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
     <meta name="generator" content={Astro.generator} />
 
     <meta property="og:locale" content="ja_JP" />
-    <meta property="og:site_name" content="Working Corgi" />
+    <meta property="og:site_name" content={site.name} />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { site } from "../config/site";
 ---
 
 <Layout
-  title="ページが見つかりません | Working Corgi"
+  title={`ページが見つかりません | ${site.name}`}
   description="お探しのページは見つかりませんでした。"
   noindex
 >

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,9 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { site } from "../config/site";
 ---
 
 <Layout
-  title="About | Working Corgi"
+  title={`About | ${site.name}`}
   description="ACorgi0125 の経歴、得意分野、現在取り組んでいることを紹介します。"
 >
   <div class="about">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import ExternalLinkIcon from "../components/ExternalLinkIcon.astro";
-import { profiles } from "../config/site";
+import { profiles, site } from "../config/site";
 
 const contactMethods = [
   {
@@ -18,7 +18,7 @@ const contactMethods = [
 ---
 
 <Layout
-  title="Contact | Working Corgi"
+  title={`Contact | ${site.name}`}
   description="ACorgi0125 への連絡方法を案内します。"
 >
   <div class="contact">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { profiles } from "../config/site";
+import { profiles, site } from "../config/site";
 ---
 
 <Layout
-  title="Working Corgi | ACorgi0125 の個人サイト"
+  title={`${site.name} | ACorgi0125 の個人サイト`}
   description="ACorgi0125 の自己紹介と制作物を掲載する個人サイトです。"
 >
   <div class="home">

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 
 import NoteMeta from "../components/NoteMeta.astro";
+import { site } from "../config/site";
 import Layout from "../layouts/Layout.astro";
 
 const publishedNotes = (
@@ -10,7 +11,7 @@ const publishedNotes = (
 ---
 
 <Layout
-  title="Notes | Working Corgi"
+  title={`Notes | ${site.name}`}
   description="ACorgi0125 の技術メモ、雑記、Development Log を掲載しています。"
 >
   <div class="notes">

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render, type CollectionEntry } from "astro:content";
 
 import { noteCategoryOgps } from "../../config/noteCategoryOgps";
+import { site } from "../../config/site";
 import NoteMeta from "../../components/NoteMeta.astro";
 import Layout from "../../layouts/Layout.astro";
 
@@ -27,7 +28,7 @@ const ogImageAlt = note.data.ogImageAlt ?? categoryOgp?.imageAlt;
 ---
 
 <Layout
-  title={`${note.data.title} | Working Corgi`}
+  title={`${note.data.title} | ${site.name}`}
   description={note.data.description}
   ogImage={ogImage}
   ogImageAlt={ogImageAlt}

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -1,9 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { site } from "../config/site";
 ---
 
 <Layout
-  title="Works | Working Corgi"
+  title={`Works | ${site.name}`}
   description="ACorgi0125 が制作している個人開発アプリと個人サイトを紹介します。"
 >
   <div class="works">


### PR DESCRIPTION
## 関連 Issue

Closes #45

<!-- `main` へマージすると、Closes #<番号> で指定した Issue が自動的に Close される。 -->

## 変更内容

- サイト名、既定 description、既定 OGP 画像と代替テキストを `src/config/site.ts` に集約
- レイアウト、ヘッダー、フッターでサイト共通設定を利用
- 固定ページと Notes 詳細ページのタイトルを共通設定から生成
- 表示文言と生成されるメタデータを変更せず、設定の重複を解消

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm run build`
- 生成 HTML のタイトル、description、OGP メタデータ、ブランド表記が変更前と一致することを確認

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認