### PR TITLE
test: Vitest を導入して Changelog の単体テストを追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ Closes #
 - [ ] 関連 Issue のリンク（該当する場合）
 - [ ] 変更差分の自己レビュー
 - [ ] `.env` 等の機密情報が含まれていないこと
-- [ ] `npm run format:check`、`npm run lint`、`npm run build` を実行
+- [ ] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
 - [ ] ブラウザで表示を確認
 - [ ] 関連ドキュメントの更新要否を確認

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Run unit tests
+        run: npm test
+
       - name: Build site
         run: npm run build
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -74,10 +74,38 @@
 3. 関連先がある場合は、サイト内ページには `link.kind: "internal"` と `link.path`、外部プロダクトには `link.kind: "external"` と `link.url` を設定する。
 4. Home の最新 5 件と `/changelog/` の全件一覧で、表示順、内容、リンク先を確認する。
 
+## 単体テスト
+
+### 対象と配置
+
+- 原則: TypeScript の純粋な関数を対象にする。
+- 配置: 対象モジュールと同じディレクトリに配置する。
+- 命名: `*.test.ts` とする。
+
+### 実行環境
+
+- 原則: Dev Container と CI の標準である Node.js 24 を使用する。
+- 例外: ブラウザ API を使うテストが必要になった場合は、DOM 環境などの追加依存を検討する。
+
+### 実行方法
+
+- 単発実行: `npm test`
+- 継続実行: `npm run test:watch`
+
 ## 検証
 
-- 実装を変更したら、変更内容に応じて `npm run format:check`、`npm run lint`、`npm run build` を実行する。
-- コミット前に `git diff --cached` を確認し、不要なファイルや機密情報が含まれていないことを確認する。
+### 実装変更後
+
+- 原則: 変更内容に応じて次のコマンドを実行する。
+- コマンド:
+  - `npm run format:check`
+  - `npm run lint`
+  - `npm test`
+  - `npm run build`
+
+### コミット前
+
+- `git diff --cached` を確認し、不要なファイルや機密情報が含まれていないことを確認する。
 
 ## コミットメッセージ
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,7 @@
   ```sh
   npm run format:check
   npm run lint
+  npm test
   npm run build
   git diff --cached
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "stylelint": "^17.14.1",
         "stylelint-config-recess-order": "^7.8.0",
         "stylelint-config-standard-scss": "^17.0.0",
-        "typescript-eslint": "^8.66.0"
+        "typescript-eslint": "^8.66.0",
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -2724,6 +2725,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2734,6 +2742,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2742,6 +2761,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3065,6 +3091,139 @@
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -3200,6 +3359,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -3424,6 +3593,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -3547,6 +3726,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "2.0.1",
@@ -4170,6 +4356,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4185,6 +4381,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6724,6 +6930,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -7517,6 +7730,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7616,6 +7836,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -8069,6 +8303,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
@@ -8101,6 +8342,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8649,6 +8900,106 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8673,6 +9024,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "lint:styles": "stylelint \"src/**/*.{scss,astro}\"",
     "lint:styles:fix": "stylelint \"src/**/*.{scss,astro}\" --fix",
     "lint": "npm run lint:code && npm run lint:styles",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js stylelint.config.mjs package.json .prettierrc.json workingcorgi.code-workspace .github",
     "format:check": "prettier --check .devcontainer .vscode docs src AGENTS.md astro.config.mjs eslint.config.js stylelint.config.mjs package.json .prettierrc.json workingcorgi.code-workspace .github"
   },
@@ -34,6 +36,7 @@
     "stylelint": "^17.14.1",
     "stylelint-config-recess-order": "^7.8.0",
     "stylelint-config-standard-scss": "^17.0.0",
-    "typescript-eslint": "^8.66.0"
+    "typescript-eslint": "^8.66.0",
+    "vitest": "^4.1.11"
   }
 }

--- a/src/components/ChangelogList.astro
+++ b/src/components/ChangelogList.astro
@@ -1,5 +1,5 @@
 ---
-import type { ChangelogEntry } from "../data/changelog";
+import type { ChangelogEntry } from "../domain/changelog";
 import { formatChangelogDate, getChangelogLinkHref } from "../utils/changelog";
 
 interface Props {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,116 +1,7 @@
-export type ChangelogLink =
-  | { readonly kind: "internal"; readonly path: string }
-  | { readonly kind: "external"; readonly url: string };
-
-export interface ChangelogEntry {
-  readonly date: string;
-  readonly title: string;
-  readonly description: string;
-  readonly link?: ChangelogLink;
-}
-
-const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-const internalPathValidationBaseUrl = new URL(
-  "https://changelog.invalid/base/",
-);
-
-const hasInvalidOrTraversalSegment = (path: string) => {
-  try {
-    const [pathname] = path.split(/[?#]/, 1);
-    return pathname
-      .split(/[\\/]/)
-      .some((segment) => [".", ".."].includes(decodeURIComponent(segment)));
-  } catch {
-    return true;
-  }
-};
-
-const validateLink = (link: ChangelogLink, title: string) => {
-  if (link.kind === "external") {
-    let url: URL;
-
-    try {
-      url = new URL(link.url);
-    } catch {
-      throw new Error(
-        `Changelog「${title}」の link.url に有効な URL を設定してください: ${link.url}`,
-      );
-    }
-
-    if (
-      link.url !== link.url.trim() ||
-      url.protocol !== "https:" ||
-      !url.hostname
-    ) {
-      throw new Error(
-        `Changelog「${title}」の link.url は有効な https:// URL にしてください: ${link.url}`,
-      );
-    }
-
-    return;
-  }
-
-  let resolvedUrl: URL;
-
-  try {
-    resolvedUrl = new URL(link.path, internalPathValidationBaseUrl);
-  } catch {
-    throw new Error(
-      `Changelog「${title}」の link.path に有効なパスを設定してください: ${link.path}`,
-    );
-  }
-
-  if (
-    !link.path ||
-    link.path !== link.path.trim() ||
-    link.path.startsWith("/") ||
-    hasInvalidOrTraversalSegment(link.path) ||
-    resolvedUrl.origin !== internalPathValidationBaseUrl.origin ||
-    !resolvedUrl.pathname.startsWith(internalPathValidationBaseUrl.pathname)
-  ) {
-    throw new Error(
-      `Changelog「${title}」の link.path は BASE_URL 配下の相対パスで設定してください: ${link.path}`,
-    );
-  }
-};
-
-const validateEntry = ({ date, title, description, link }: ChangelogEntry) => {
-  if (!title.trim()) {
-    throw new Error("Changelog の title は空にできません。");
-  }
-
-  if (!description.trim()) {
-    throw new Error(`Changelog「${title}」の description は空にできません。`);
-  }
-
-  if (!datePattern.test(date)) {
-    throw new Error(
-      `Changelog「${title}」の date は YYYY-MM-DD 形式で設定してください: ${date}`,
-    );
-  }
-
-  const parsedDate = new Date(`${date}T00:00:00Z`);
-
-  if (
-    Number.isNaN(parsedDate.valueOf()) ||
-    parsedDate.toISOString().slice(0, 10) !== date
-  ) {
-    throw new Error(`Changelog「${title}」の date が不正です: ${date}`);
-  }
-
-  if (link) {
-    validateLink(link, title);
-  }
-};
-
-const createChangelogEntries = (
-  entries: readonly ChangelogEntry[],
-): readonly ChangelogEntry[] => {
-  entries.forEach(validateEntry);
-  return Object.freeze(
-    entries.toSorted((a, b) => b.date.localeCompare(a.date)),
-  );
-};
+import {
+  prepareChangelogEntries,
+  type ChangelogEntry,
+} from "../domain/changelog";
 
 const rawChangelogEntries = [
   {
@@ -175,4 +66,4 @@ const rawChangelogEntries = [
   },
 ] as const satisfies readonly ChangelogEntry[];
 
-export const changelogEntries = createChangelogEntries(rawChangelogEntries);
+export const changelogEntries = prepareChangelogEntries(rawChangelogEntries);

--- a/src/domain/changelog.test.ts
+++ b/src/domain/changelog.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { prepareChangelogEntries, type ChangelogEntry } from "./changelog";
+
+const createEntry = (
+  overrides: Partial<ChangelogEntry> = {},
+): ChangelogEntry => ({
+  date: "2026-08-20",
+  title: "更新タイトル",
+  description: "更新内容の説明",
+  ...overrides,
+});
+
+const expectEntryToBeRejected = (
+  overrides: Partial<ChangelogEntry>,
+  expected: string | RegExp,
+) => {
+  expect(() => prepareChangelogEntries([createEntry(overrides)])).toThrow(
+    expected,
+  );
+};
+
+describe("prepareChangelogEntries", () => {
+  describe("項目の検証", () => {
+    it.each([
+      ["リンクなし", undefined],
+      ["内部リンク", { kind: "internal", path: "notes/" }],
+      ["外部リンク", { kind: "external", url: "https://example.com/product" }],
+    ] satisfies [string, ChangelogEntry["link"]][])(
+      "%sの正しい項目を受け入れる",
+      (_label, link) => {
+        const entry = createEntry({ link });
+
+        expect(prepareChangelogEntries([entry])).toEqual([entry]);
+      },
+    );
+
+    it.each(["", " ", "\t\n"])("空の title %j を拒否する", (title) => {
+      expectEntryToBeRejected({ title }, "title は空にできません");
+    });
+
+    it.each(["", " ", "\t\n"])(
+      "空の description %j を拒否する",
+      (description) => {
+        expectEntryToBeRejected(
+          { description },
+          "description は空にできません",
+        );
+      },
+    );
+  });
+
+  describe("日付の検証", () => {
+    it("閏年の2月29日を受け入れる", () => {
+      const entry = createEntry({ date: "2024-02-29" });
+
+      expect(prepareChangelogEntries([entry])).toEqual([entry]);
+    });
+
+    it.each(["2026-02-29", "2026-04-31", "2026-13-01", "2026-00-01"])(
+      "存在しない日付 %s を拒否する",
+      (date) => {
+        expectEntryToBeRejected({ date }, "date が不正です");
+      },
+    );
+
+    it.each(["2026-8-20", "2026/08/20", "20-08-2026", "2026-08-20T00:00:00Z"])(
+      "YYYY-MM-DD 以外の日付 %s を拒否する",
+      (date) => {
+        expectEntryToBeRejected({ date }, "YYYY-MM-DD 形式");
+      },
+    );
+  });
+
+  describe("リンクの検証", () => {
+    it.each([
+      "not-a-url",
+      " https://example.com",
+      "https://example.com ",
+      "http://example.com",
+      "ftp://example.com",
+      "https://",
+    ])("不正な外部 URL %j を拒否する", (url) => {
+      const link = { kind: "external", url } as const;
+
+      expectEntryToBeRejected({ link }, /link.url/);
+    });
+
+    it.each([
+      "",
+      " ",
+      " notes/",
+      "notes/ ",
+      "/notes/",
+      "https://example.com/notes/",
+      "notes/%",
+      ".",
+      "..",
+      "./notes/",
+      "notes/../works/",
+      "%2e/notes/",
+      "notes/%2E%2E/works/",
+      "notes\\..\\works/",
+      "notes%2F..%2Fworks/",
+      "notes%5C..%5Cworks/",
+    ])("不正な内部パス %j を拒否する", (path) => {
+      const link = { kind: "internal", path } as const;
+
+      expectEntryToBeRejected({ link }, /link.path/);
+    });
+  });
+
+  describe("並び替えと不変性", () => {
+    it("更新日の降順に並べる", () => {
+      const oldest = createEntry({ date: "2026-08-01", title: "古い更新" });
+      const newest = createEntry({ date: "2026-08-20", title: "新しい更新" });
+      const middle = createEntry({ date: "2026-08-10", title: "中間の更新" });
+
+      expect(prepareChangelogEntries([oldest, newest, middle])).toEqual([
+        newest,
+        middle,
+        oldest,
+      ]);
+    });
+
+    it("更新日が同じ項目は入力順を維持する", () => {
+      const first = createEntry({ title: "同日の最初の更新" });
+      const second = createEntry({ title: "同日の次の更新" });
+
+      expect(prepareChangelogEntries([first, second])).toEqual([first, second]);
+    });
+
+    it("元の入力配列を変更しない", () => {
+      const older = createEntry({ date: "2026-08-01", title: "古い更新" });
+      const newer = createEntry({ date: "2026-08-20", title: "新しい更新" });
+      const entries = [older, newer];
+      const originalOrder = [...entries];
+
+      const result = prepareChangelogEntries(entries);
+
+      expect(entries).toEqual(originalOrder);
+      expect(result).not.toBe(entries);
+    });
+
+    it("読み取り専用の結果配列を実行時にも凍結する", () => {
+      const result = prepareChangelogEntries([createEntry()]);
+
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+  });
+});

--- a/src/domain/changelog.ts
+++ b/src/domain/changelog.ts
@@ -1,0 +1,125 @@
+export type ChangelogLink =
+  | { readonly kind: "internal"; readonly path: string }
+  | { readonly kind: "external"; readonly url: string };
+
+export interface ChangelogEntry {
+  readonly date: string;
+  readonly title: string;
+  readonly description: string;
+  readonly link?: ChangelogLink;
+}
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const internalPathValidationBaseUrl = new URL(
+  "https://changelog.invalid/base/",
+);
+
+const hasInvalidPathSegment = (path: string) => {
+  try {
+    const [pathname] = path.split(/[?#]/, 1);
+    return decodeURIComponent(pathname)
+      .split(/[\\/]/)
+      .some((segment) => segment === "." || segment === "..");
+  } catch {
+    return true;
+  }
+};
+
+const assertValidExternalUrl = (externalUrl: string, title: string) => {
+  let url: URL;
+
+  try {
+    url = new URL(externalUrl);
+  } catch {
+    throw new Error(
+      `Changelog「${title}」の link.url に有効な URL を設定してください: ${externalUrl}`,
+    );
+  }
+
+  if (
+    externalUrl !== externalUrl.trim() ||
+    url.protocol !== "https:" ||
+    !url.hostname
+  ) {
+    throw new Error(
+      `Changelog「${title}」の link.url は有効な https:// URL にしてください: ${externalUrl}`,
+    );
+  }
+};
+
+const assertValidInternalPath = (path: string, title: string) => {
+  let resolvedUrl: URL;
+
+  try {
+    resolvedUrl = new URL(path, internalPathValidationBaseUrl);
+  } catch {
+    throw new Error(
+      `Changelog「${title}」の link.path に有効なパスを設定してください: ${path}`,
+    );
+  }
+
+  if (
+    !path ||
+    path !== path.trim() ||
+    path.startsWith("/") ||
+    hasInvalidPathSegment(path) ||
+    resolvedUrl.origin !== internalPathValidationBaseUrl.origin ||
+    !resolvedUrl.pathname.startsWith(internalPathValidationBaseUrl.pathname)
+  ) {
+    throw new Error(
+      `Changelog「${title}」の link.path は BASE_URL 配下の相対パスで設定してください: ${path}`,
+    );
+  }
+};
+
+const assertValidLink = (link: ChangelogLink, title: string) => {
+  if (link.kind === "external") {
+    assertValidExternalUrl(link.url, title);
+    return;
+  }
+
+  assertValidInternalPath(link.path, title);
+};
+
+const assertValidEntry = ({
+  date,
+  title,
+  description,
+  link,
+}: ChangelogEntry) => {
+  if (!title.trim()) {
+    throw new Error("Changelog の title は空にできません。");
+  }
+
+  if (!description.trim()) {
+    throw new Error(`Changelog「${title}」の description は空にできません。`);
+  }
+
+  if (!datePattern.test(date)) {
+    throw new Error(
+      `Changelog「${title}」の date は YYYY-MM-DD 形式で設定してください: ${date}`,
+    );
+  }
+
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+
+  if (
+    Number.isNaN(parsedDate.valueOf()) ||
+    parsedDate.toISOString().slice(0, 10) !== date
+  ) {
+    throw new Error(`Changelog「${title}」の date が不正です: ${date}`);
+  }
+
+  if (link) {
+    assertValidLink(link, title);
+  }
+};
+
+export const prepareChangelogEntries = (
+  entries: readonly ChangelogEntry[],
+): readonly ChangelogEntry[] => {
+  entries.forEach(assertValidEntry);
+  return Object.freeze(
+    entries.toSorted((a, b) => b.date.localeCompare(a.date)),
+  );
+};

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -1,4 +1,4 @@
-import type { ChangelogLink } from "../data/changelog";
+import type { ChangelogLink } from "../domain/changelog";
 
 export const formatChangelogDate = (date: string) => date.replaceAll("-", ".");
 


### PR DESCRIPTION
## 関連 Issue

Closes #50

<!-- `main` へマージすると、Closes #<番号> で指定した Issue が自動的に Close される。 -->

## 変更内容

- Vitest を導入し、単発実行と watch モード用の npm scripts を追加
- Changelog の検証・並び替え処理を純粋な関数としてドメイン層へ分離
- Changelog の正常系、異常系、並び順、不変性を確認する単体テストを追加
- GitHub Actions の lint 後、build 前に単体テストを実行
- テストの配置・実行方法と開発手順、Pull Request テンプレートを更新

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`（44件成功）
- Changelog の既存データ処理と表示側の参照関係を確認

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認（表示変更がないため対象外）
- [x] 関連ドキュメントの更新要否を確認