### PR TITLE
chore: Dev Container に GitHub CLI を追加

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4",
+      "integrity": "sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,14 @@
 {
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:5-24-trixie",
-  "mounts": ["source=codex-private-state,target=/home/node/.codex,type=volume"],
-  "postCreateCommand": "npm ci",
+  "mounts": [
+    "source=codex-private-state,target=/home/node/.codex,type=volume",
+    "source=github-cli-private-state,target=/home/node/.config/gh,type=volume"
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "sudo chown -R node:node /home/node/.config/gh && npm ci",
   "postStartCommand": "npm run dev -- --background",
   "forwardPorts": [4321],
   "portsAttributes": {

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,42 @@
   docker volume rm codex-private-state
   ```
 
+## GitHub CLI
+
+- Dev Container には GitHub CLI（`gh`）が含まれている。
+- 原則: 認証情報は Docker ホストごとの `github-cli-private-state` ボリュームに保存する。
+- 禁止: 認証情報を Git 管理・共有しない。
+
+### 初期設定
+
+```sh
+gh auth login
+gh auth status
+```
+
+### 利用例
+
+- リポジトリ・Issue の確認
+
+  ```sh
+  gh repo view
+  gh issue list
+  ```
+
+- PR のチェック結果の確認（現在のブランチに PR がある場合のみ）
+
+  ```sh
+  gh pr checks
+  ```
+
+### 認証情報の削除
+
+- 注意: ボリュームを削除すると認証状態が失われる。
+
+```sh
+docker volume rm github-cli-private-state
+```
+
 ## 実装と確認
 
 - 実装前に `docs/product.md` と `docs/conventions.md` を確認する。


### PR DESCRIPTION
## 関連 Issue

Closes #19

## 変更内容

- Dev Container に GitHub CLI Feature を追加
- GitHub CLI の認証情報を `github-cli-private-state` 名前付きボリュームへ保存
- 認証情報用ボリュームの所有権を Dev Container 作成時に `node` ユーザーへ設定
- GitHub CLI Feature のバージョンを lock ファイルで固定
- GitHub CLI の初期設定・利用例・認証情報削除手順を開発ドキュメントへ追加

## 確認内容

- Dev Container を再ビルドし、`gh --version` を確認
- `gh auth login` 後、再ビルドしても認証状態が保持されることを確認
- `gh auth status`、`gh repo view`、`gh issue list` が成功
- `gh pr checks` は現在のブランチに PR がないため、対象なしとなることを確認
- `npm run format:check`、`npm run lint`、`npm test`、`npm run build` が成功

## チェックリスト

- [x] 関連 Issue のリンク
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認（表示変更なしのため不要）
- [x] 関連ドキュメントの更新要否を確認