### PR TITLE
docs: ローカルの GA4 運用を明記

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -93,7 +93,13 @@ docker volume rm github-cli-private-state
 ### ローカル環境
 
 - 原則: `.env` の `PUBLIC_GA_MEASUREMENT_ID` をコメントアウトし、GA4 を読み込まない。
-- 例外: 動作確認などで必要な場合のみ、`PUBLIC_GA_MEASUREMENT_ID` のコメントアウトを外す。
+- 例外: 必要な場合のみ、`.env` の `PUBLIC_GA_MEASUREMENT_ID` のコメントアウトを外す。
+- 厳守: `PUBLIC_GA_MEASUREMENT_ID` を変更した後は、開発サーバーを再起動する。
+
+  ```sh
+  astro dev stop
+  astro dev --background
+  ```
 
 ### 同意管理
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,6 +90,11 @@ docker volume rm github-cli-private-state
 - 測定 ID が未設定の場合、Google タグと同意バナーを出力しない。
 - 測定 ID は公開情報。認証情報は Git 管理しない。
 
+### ローカル環境
+
+- 原則: `.env` の `PUBLIC_GA_MEASUREMENT_ID` をコメントアウトし、GA4 を読み込まない。
+- 例外: 動作確認などで必要な場合のみ、`PUBLIC_GA_MEASUREMENT_ID` のコメントアウトを外す。
+
 ### 同意管理
 
 - 厳守: 利用者が許可するまで計測しない。


### PR DESCRIPTION
## 関連 Issue

なし

## 変更内容

- Google Analytics の開発手順にローカル環境の運用を追加
- 通常は測定 ID をコメントアウトして GA4 を読み込まない方針を明記
- 動作確認時だけ測定 ID を有効化する例外を明記

## 確認内容

- `npm run format:check`
- `git diff --check`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [ ] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [ ] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認