### PR TITLE
fix: Notes のコードブロック表示を整える (#68)

### DIFF
--- a/src/data/discussionArticles.ts
+++ b/src/data/discussionArticles.ts
@@ -48,8 +48,44 @@ const headingAnchorOptions = {
   },
 };
 
+const codeHighlightTheme = {
+  name: "working-corgi-dark",
+  type: "dark",
+  colors: {
+    "editor.background": "#312d29",
+    "editor.foreground": "#f8f4ec",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment", "string.comment"],
+      settings: { foreground: "#b8afa6" },
+    },
+    {
+      scope: ["constant", "support", "meta.property-name"],
+      settings: { foreground: "#dce8de" },
+    },
+    {
+      scope: ["entity", "entity.name"],
+      settings: { foreground: "#c69a4a" },
+    },
+    {
+      scope: ["keyword", "storage", "storage.type"],
+      settings: { foreground: "#ebd0c4" },
+    },
+    {
+      scope: ["string", "punctuation.definition.string"],
+      settings: { foreground: "#dce8de" },
+    },
+    {
+      scope: "variable",
+      settings: { foreground: "#f8f4ec" },
+    },
+  ],
+};
+
 const markdownProcessor = createMarkdownProcessor({
   remarkRehype: { allowDangerousHtml: false },
+  shikiConfig: { theme: codeHighlightTheme },
   rehypePlugins: [
     rehypeHeadingIds,
     [rehypeAutolinkHeadings, headingAnchorOptions],

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -49,7 +49,89 @@ const ogImageAlt = categoryOgp?.imageAlt;
       <p class="note__description">{note.description}</p>
     </header>
 
-    <div class="note__content" set:html={discussionArticleHtml} />
+    <div
+      class="note__content"
+      data-note-code-blocks
+      set:html={discussionArticleHtml}
+    />
+
+    <script>
+      // Code block enhancements
+      const copyLabel = "Copy";
+      const copiedLabel = "Copied!";
+      const copyErrorLabel = "Try again";
+      const codeBlocks = document.querySelector<HTMLElement>(
+        "[data-note-code-blocks]",
+      );
+      const languageLabels: Record<string, string> = {
+        text: "Plain text",
+        plaintext: "Plain text",
+        md: "Markdown",
+        markdown: "Markdown",
+        ts: "TypeScript",
+        typescript: "TypeScript",
+        js: "JavaScript",
+        javascript: "JavaScript",
+        css: "CSS",
+        html: "HTML",
+        json: "JSON",
+        sh: "Shell",
+        bash: "Shell",
+        yml: "YAML",
+        yaml: "YAML",
+      };
+
+      const getLanguageLabel = (language: string) =>
+        languageLabels[language.toLowerCase()] ?? language;
+
+      const copyCode = async (code: Element) => {
+        if (!navigator.clipboard) {
+          return false;
+        }
+
+        try {
+          await navigator.clipboard.writeText(code.textContent ?? "");
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      const createCopyButton = (code: Element) => {
+        const button = document.createElement("button");
+
+        button.className = "note__code-copy";
+        button.type = "button";
+        button.textContent = copyLabel;
+        button.setAttribute("aria-label", "コードをコピー");
+        button.addEventListener("click", async () => {
+          button.textContent = (await copyCode(code))
+            ? copiedLabel
+            : copyErrorLabel;
+
+          window.setTimeout(() => {
+            button.textContent = copyLabel;
+          }, 2000);
+        });
+
+        return button;
+      };
+
+      const enhanceCodeBlock = (code: Element) => {
+        const pre = code.parentElement;
+
+        if (!pre) {
+          return;
+        }
+
+        pre.dataset.languageLabel = getLanguageLabel(
+          pre.dataset.language ?? "text",
+        );
+        pre.append(createCopyButton(code));
+      };
+
+      codeBlocks?.querySelectorAll("pre > code").forEach(enhanceCodeBlock);
+    </script>
 
     <GiscusComments
       discussion={{
@@ -209,13 +291,92 @@ const ogImageAlt = categoryOgp?.imageAlt;
     color: var(--color-accent-strong);
   }
 
-  .note__content :global(code) {
+  .note__content :global(:not(pre) > code) {
     padding: 0.1em 0.35em;
     font-size: 0.875em;
     color: var(--color-accent-strong);
     background: var(--color-accent-soft);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
+  }
+
+  .note__content :global(pre) {
+    --note-code-overlay: rgb(248 244 236 / 15%);
+
+    position: relative;
+    max-width: 100%;
+    padding: var(--space-md);
+    margin-block: var(--space-xl);
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.55;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+  }
+
+  .note__content :global(pre > code) {
+    display: block;
+    min-width: max-content;
+    padding-top: var(--space-sm);
+    white-space: normal;
+    counter-reset: code-line;
+    border-top: 1px solid var(--note-code-overlay);
+  }
+
+  .note__content :global(pre > code > .line) {
+    display: block;
+    white-space: pre;
+    counter-increment: code-line;
+  }
+
+  .note__content :global(pre > code > .line::before) {
+    display: inline-block;
+    min-width: 3ch;
+    margin-right: var(--space-md);
+    font-variant-numeric: tabular-nums;
+    color: rgb(248 244 236 / 45%);
+    text-align: right;
+    user-select: none;
+    content: counter(code-line);
+  }
+
+  .note__content :global(pre[data-language-label]::before) {
+    display: block;
+    margin-bottom: var(--space-sm);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-accent-soft);
+    letter-spacing: 0.03em;
+    content: attr(data-language-label);
+  }
+
+  .note__content :global(.note__code-copy) {
+    position: absolute;
+    top: var(--space-sm);
+    right: var(--space-sm);
+    min-width: 24px;
+    min-height: 24px;
+    padding-block: 1px;
+    padding-inline: 6px;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-accent-soft);
+    cursor: pointer;
+    background: var(--note-code-overlay);
+    border: 1px solid rgb(248 244 236 / 25%);
+    border-radius: var(--radius-sm);
+
+    &:hover {
+      background: rgb(248 244 236 / 25%);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-focus);
+      outline-offset: 2px;
+    }
   }
 
   .note__footer {

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -60,6 +60,8 @@ const ogImageAlt = categoryOgp?.imageAlt;
       const copyLabel = "Copy";
       const copiedLabel = "Copied!";
       const copyErrorLabel = "Try again";
+      const copySuccessAnnouncement = "コードをコピーしました。";
+      const copyErrorAnnouncement = "コードをコピーできませんでした。";
       const codeBlocks = document.querySelector<HTMLElement>(
         "[data-note-code-blocks]",
       );
@@ -97,7 +99,17 @@ const ogImageAlt = categoryOgp?.imageAlt;
         }
       };
 
-      const createCopyButton = (code: Element) => {
+      const createCopyStatus = () => {
+        const status = document.createElement("span");
+
+        status.className = "visually-hidden";
+        status.setAttribute("aria-live", "polite");
+        status.setAttribute("aria-atomic", "true");
+
+        return status;
+      };
+
+      const createCopyButton = (code: Element, status: HTMLSpanElement) => {
         const button = document.createElement("button");
 
         button.className = "note__code-copy";
@@ -105,9 +117,12 @@ const ogImageAlt = categoryOgp?.imageAlt;
         button.textContent = copyLabel;
         button.setAttribute("aria-label", "コードをコピー");
         button.addEventListener("click", async () => {
-          button.textContent = (await copyCode(code))
-            ? copiedLabel
-            : copyErrorLabel;
+          const copied = await copyCode(code);
+
+          button.textContent = copied ? copiedLabel : copyErrorLabel;
+          status.textContent = copied
+            ? copySuccessAnnouncement
+            : copyErrorAnnouncement;
 
           window.setTimeout(() => {
             button.textContent = copyLabel;
@@ -124,10 +139,12 @@ const ogImageAlt = categoryOgp?.imageAlt;
           return;
         }
 
+        const status = createCopyStatus();
+
         pre.dataset.languageLabel = getLanguageLabel(
           pre.dataset.language ?? "text",
         );
-        pre.append(createCopyButton(code));
+        pre.append(createCopyButton(code, status), status);
       };
 
       codeBlocks?.querySelectorAll("pre > code").forEach(enhanceCodeBlock);

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -391,7 +391,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
     }
 
     &:focus-visible {
-      outline: 2px solid var(--color-focus);
+      outline: 2px solid var(--color-accent-soft);
       outline-offset: 2px;
     }
   }


### PR DESCRIPTION
## 関連 Issue

Closes #68

## 変更内容

- Notes の Markdown コードブロックをサイトに合うチャコール基調の Shiki テーマで表示
- コードブロックに言語名、行番号、横スクロール、Copy 按钮を追加
- インラインコードの装飾がコードブロック内へ適用されないよう修正
- Shiki の出力する改行による余分な行間を解消
- コピー按钮のタップ領域を確保し、成功・失敗時の表示を追加

## 確認内容

- Notes のコードブロックで配色、言語名、行番号、Copy 按钮をブラウザで確認
- 横長のコードブロックが横スクロールできることを確認
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認