### PR TITLE
fix: Notes のテーブルを狭い画面で横スクロール可能にする (#69)

### DIFF
--- a/src/data/discussionArticles.test.ts
+++ b/src/data/discussionArticles.test.ts
@@ -239,4 +239,14 @@ describe("renderDiscussionArticleBody", () => {
       'aria-label="\u8868\u3092\u6a2a\u306b\u30b9\u30af\u30ed\u30fc\u30eb"',
     );
   });
+
+  it("makes the code block scroll region keyboard focusable", async () => {
+    const { renderDiscussionArticleBody } =
+      await import("./discussionArticles");
+    const html = await renderDiscussionArticleBody({
+      body: "```ts\nconst longLine = 'Content';\n```",
+    });
+
+    expect(html).toMatch(/<pre(?![^>]*tabindex)[^>]*>\s*<code tabindex="0">/);
+  });
 });

--- a/src/data/discussionArticles.test.ts
+++ b/src/data/discussionArticles.test.ts
@@ -223,3 +223,20 @@ describe("getDiscussionArticles", () => {
     expect(getCachedDiscussionArticles).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("renderDiscussionArticleBody", () => {
+  it("wraps Markdown tables in a scrollable region", async () => {
+    const { renderDiscussionArticleBody } =
+      await import("./discussionArticles");
+    const html = await renderDiscussionArticleBody({
+      body: "| Name | Value |\n| --- | --- |\n| Long name | Content |",
+    });
+
+    expect(html).toMatch(/<div class="note__table-scroll"[^>]*>\s*<table>/);
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain('role="region"');
+    expect(html).toContain(
+      'aria-label="\u8868\u3092\u6a2a\u306b\u30b9\u30af\u30ed\u30fc\u30eb"',
+    );
+  });
+});

--- a/src/data/discussionArticles.ts
+++ b/src/data/discussionArticles.ts
@@ -35,10 +35,45 @@ interface DiscussionArticlesGraphqlData {
   };
 }
 
+interface HtmlNode {
+  readonly type: string;
+  readonly tagName?: string;
+  readonly properties?: Record<string, unknown>;
+  readonly children?: HtmlNode[];
+}
+
 const repository = { owner: "t-ooshiro0125", name: "workingcorgi" };
 const articlesCategorySlug = "articles";
 
 // Markdown rendering
+const tableScrollProperties = {
+  className: ["note__table-scroll"],
+  tabIndex: 0,
+  role: "region",
+  ariaLabel: "\u8868\u3092\u6a2a\u306b\u30b9\u30af\u30ed\u30fc\u30eb",
+};
+
+const createScrollableTable = (table: HtmlNode): HtmlNode => ({
+  type: "element",
+  tagName: "div",
+  properties: tableScrollProperties,
+  children: [table],
+});
+
+const wrapTables = (children: HtmlNode[]) => {
+  for (const [index, child] of children.entries()) {
+    if (child.type === "element" && child.tagName === "table") {
+      children[index] = createScrollableTable(child);
+    } else if (child.children) {
+      wrapTables(child.children);
+    }
+  }
+};
+
+const rehypeWrapTables = () => (tree: HtmlNode) => {
+  wrapTables(tree.children ?? []);
+};
+
 const headingAnchorOptions = {
   behavior: "append",
   content: { type: "text", value: "#" },
@@ -89,6 +124,7 @@ const markdownProcessor = createMarkdownProcessor({
   rehypePlugins: [
     rehypeHeadingIds,
     [rehypeAutolinkHeadings, headingAnchorOptions],
+    rehypeWrapTables,
   ],
 });
 
@@ -251,7 +287,7 @@ export const getDiscussionArticles = () =>
 
 /** Discussion の Markdown 本文を表示用 HTML に変換する。 */
 export const renderDiscussionArticleBody = async (
-  article: DiscussionArticle,
+  article: Pick<DiscussionArticle, "body">,
 ) => {
   const processor = await markdownProcessor;
   const { code } = await processor.render(article.body);

--- a/src/data/discussionArticles.ts
+++ b/src/data/discussionArticles.ts
@@ -53,25 +53,64 @@ const tableScrollProperties = {
   ariaLabel: "\u8868\u3092\u6a2a\u306b\u30b9\u30af\u30ed\u30fc\u30eb",
 };
 
-const createScrollableTable = (table: HtmlNode): HtmlNode => ({
-  type: "element",
-  tagName: "div",
-  properties: tableScrollProperties,
-  children: [table],
-});
+const isElement = (node: HtmlNode, tagName: string) =>
+  node.type === "element" && node.tagName === tagName;
 
-const wrapTables = (children: HtmlNode[]) => {
+const wrapTable = (node: HtmlNode): HtmlNode => {
+  if (!isElement(node, "table")) {
+    return node;
+  }
+
+  return {
+    type: "element",
+    tagName: "div",
+    properties: tableScrollProperties,
+    children: [node],
+  };
+};
+
+const makeCodeBlockKeyboardScrollable = (node: HtmlNode): HtmlNode => {
+  if (!isElement(node, "pre")) {
+    return node;
+  }
+
+  const properties = { ...node.properties };
+
+  delete properties.tabIndex;
+  delete properties.tabindex;
+
+  return {
+    ...node,
+    properties,
+    children: node.children?.map((code) =>
+      isElement(code, "code")
+        ? {
+            ...code,
+            properties: { ...code.properties, tabIndex: 0 },
+          }
+        : code,
+    ),
+  };
+};
+
+const enhanceNoteHtmlNode = (node: HtmlNode) =>
+  makeCodeBlockKeyboardScrollable(wrapTable(node));
+
+const transformHtmlNodes = (
+  children: HtmlNode[],
+  transform: (node: HtmlNode) => HtmlNode,
+) => {
   for (const [index, child] of children.entries()) {
-    if (child.type === "element" && child.tagName === "table") {
-      children[index] = createScrollableTable(child);
-    } else if (child.children) {
-      wrapTables(child.children);
+    if (child.children) {
+      transformHtmlNodes(child.children, transform);
     }
+
+    children[index] = transform(child);
   }
 };
 
-const rehypeWrapTables = () => (tree: HtmlNode) => {
-  wrapTables(tree.children ?? []);
+const rehypeEnhanceNotesContent = () => (tree: HtmlNode) => {
+  transformHtmlNodes(tree.children ?? [], enhanceNoteHtmlNode);
 };
 
 const headingAnchorOptions = {
@@ -124,7 +163,7 @@ const markdownProcessor = createMarkdownProcessor({
   rehypePlugins: [
     rehypeHeadingIds,
     [rehypeAutolinkHeadings, headingAnchorOptions],
-    rehypeWrapTables,
+    rehypeEnhanceNotesContent,
   ],
 });
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,6 +100,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
       position: relative;
       display: grid;
       grid-template-rows: auto 1fr auto;
+      grid-template-columns: minmax(0, 1fr);
       min-height: 100svh;
     }
 

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -141,6 +141,9 @@ const ogImageAlt = categoryOgp?.imageAlt;
 
         const status = createCopyStatus();
 
+        pre.style.overflowX = "hidden";
+        pre.removeAttribute("tabindex");
+        code.setAttribute("tabindex", "0");
         pre.dataset.languageLabel = getLanguageLabel(
           pre.dataset.language ?? "text",
         );
@@ -200,6 +203,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
 
   .note__content {
     padding: var(--space-xl);
+    container-type: inline-size;
     line-height: 1.9;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -278,13 +282,36 @@ const ogImageAlt = categoryOgp?.imageAlt;
 
   .note__content :global(table) {
     width: 100%;
-    margin-block: var(--space-xl);
+    min-width: 0;
     overflow: hidden;
     font-size: 0.9375rem;
     border-spacing: 0;
     border-collapse: separate;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
+  }
+
+  .note__content :global(.note__table-scroll) {
+    max-width: 100%;
+    margin-block: var(--space-xl);
+    overflow-x: auto;
+  }
+
+  @container (max-width: 36rem) {
+    .note__content :global(.note__table-scroll)::before {
+      display: block;
+      width: max-content;
+      margin-bottom: var(--space-xs);
+      font-size: 0.75rem;
+      font-weight: 400;
+      color: var(--color-text-muted);
+      content: "横にスクロールできます →";
+    }
+
+    .note__content :global(table) {
+      width: max-content;
+      min-width: 36rem;
+    }
   }
 
   .note__content :global(th),
@@ -324,7 +351,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
     max-width: 100%;
     padding: var(--space-md);
     margin-block: var(--space-xl);
-    overflow-x: auto;
+    overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.55;
     border: 1px solid var(--color-border);
@@ -333,8 +360,9 @@ const ogImageAlt = categoryOgp?.imageAlt;
 
   .note__content :global(pre > code) {
     display: block;
-    min-width: max-content;
+    max-width: 100%;
     padding-top: var(--space-sm);
+    overflow-x: auto;
     white-space: normal;
     counter-reset: code-line;
     border-top: 1px solid var(--note-code-overlay);

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -142,8 +142,6 @@ const ogImageAlt = categoryOgp?.imageAlt;
         const status = createCopyStatus();
 
         pre.style.overflowX = "hidden";
-        pre.removeAttribute("tabindex");
-        code.setAttribute("tabindex", "0");
         pre.dataset.languageLabel = getLanguageLabel(
           pre.dataset.language ?? "text",
         );


### PR DESCRIPTION
## 関連 Issue

Closes #69

## 変更内容

- Markdown のテーブルをビルド時にスクロール領域でラップし、狭い画面で横スクロールできるようにしました
- コンテナクエリにより、通常幅ではテーブルをそのまま表示し、狭い幅でのみスクロール表示と案内文を出すようにしました
- グリッドレイアウトの最小幅を調整し、Notes ページ全体が横方向にはみ出す問題を修正しました
- 横スクロールするコードブロックでもコピーボタンが画面外へ移動しないようにしました
- テーブル変換処理のテストを追加・整理しました

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- ブラウザで狭い画面幅のテーブル横スクロールと、ページ全体の横はみ出しがないことを確認

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認