### PR TITLE
feat: Notes タイトルのインラインコードを表示する

### DIFF
--- a/src/components/DiscussionArticleTitle.astro
+++ b/src/components/DiscussionArticleTitle.astro
@@ -1,0 +1,21 @@
+---
+import type { DiscussionArticleTitlePart } from "../domain/discussionArticle";
+
+interface Props {
+  readonly parts: readonly DiscussionArticleTitlePart[];
+}
+
+const { parts } = Astro.props;
+---
+
+{
+  parts.map((part) =>
+    part.type === "code" ? <code>{part.value}</code> : part.value,
+  )
+}
+
+<style lang="scss">
+  code {
+    color: var(--color-accent-strong);
+  }
+</style>

--- a/src/data/discussionArticlesCache.test.ts
+++ b/src/data/discussionArticlesCache.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { DiscussionArticle } from "../domain/discussionArticle";
+
 import {
   getCachedDiscussionArticles,
   writeDiscussionArticlesCache,
@@ -21,6 +23,16 @@ const cachedArticle = {
   category: "tech" as const,
   body: "本文",
 };
+
+const createArticle = (
+  overrides: Partial<DiscussionArticle> = {},
+): DiscussionArticle => ({
+  ...cachedArticle,
+  plainTitle: cachedArticle.title,
+  titleParts: [{ type: "text", value: cachedArticle.title }],
+  pubDate: new Date(cachedArticle.pubDate),
+  ...overrides,
+});
 
 const createCacheDirectory = async () => {
   const directory = await mkdtemp(join(tmpdir(), "workingcorgi-notes-"));
@@ -88,12 +100,27 @@ describe("getCachedDiscussionArticles", () => {
 });
 
 describe("writeDiscussionArticlesCache", () => {
+  it("インラインコードを含むタイトルを往復しても表示用の部分を維持する", async () => {
+    const directory = await createCacheDirectory();
+    const article = createArticle({
+      title: "Astro の `getStaticPaths`",
+      plainTitle: "Astro の getStaticPaths",
+      titleParts: [
+        { type: "text" as const, value: "Astro の " },
+        { type: "code" as const, value: "getStaticPaths" },
+      ],
+    });
+
+    await writeDiscussionArticlesCache([article], directory);
+
+    await expect(getCachedDiscussionArticles(directory)).resolves.toMatchObject(
+      [article],
+    );
+  });
+
   it("記事データと index を保存する", async () => {
     const directory = await createCacheDirectory();
-    await writeDiscussionArticlesCache(
-      [{ ...cachedArticle, pubDate: new Date(cachedArticle.pubDate) }],
-      directory,
-    );
+    await writeDiscussionArticlesCache([createArticle()], directory);
 
     await expect(
       readFile(join(directory, "index.json"), "utf8").then(JSON.parse),
@@ -102,17 +129,14 @@ describe("writeDiscussionArticlesCache", () => {
       readFile(join(directory, cachedArticle.id + ".json"), "utf8").then(
         JSON.parse,
       ),
-    ).resolves.toMatchObject({ id: cachedArticle.id });
+    ).resolves.toEqual(cachedArticle);
   });
 
   it("同期対象から外れた記事データを削除する", async () => {
     const directory = await createCacheDirectory();
     await writeFile(join(directory, "old-article.json"), "{}");
 
-    await writeDiscussionArticlesCache(
-      [{ ...cachedArticle, pubDate: new Date(cachedArticle.pubDate) }],
-      directory,
-    );
+    await writeDiscussionArticlesCache([createArticle()], directory);
 
     await expect(
       readFile(join(directory, "old-article.json"), "utf8"),

--- a/src/data/discussionArticlesCache.ts
+++ b/src/data/discussionArticlesCache.ts
@@ -12,7 +12,10 @@ import {
   noteCategoryValues,
   type NoteCategory,
 } from "../config/noteCategories";
-import type { DiscussionArticle } from "../domain/discussionArticle";
+import {
+  parseDiscussionArticleTitle,
+  type DiscussionArticle,
+} from "../domain/discussionArticle";
 
 const defaultCacheDirectory = resolve(".cache/notes");
 const indexFileName = "index.json";
@@ -20,7 +23,7 @@ const articleIdPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 type CachedDiscussionArticle = Omit<
   DiscussionArticle,
-  "pubDate" | "updatedDate"
+  "plainTitle" | "titleParts" | "pubDate" | "updatedDate"
 > & {
   readonly pubDate: string;
   readonly updatedDate?: string;
@@ -119,7 +122,10 @@ const parseArticle = (value: unknown, id: string): DiscussionArticle => {
     id,
     discussionNumber: article.discussionNumber,
     discussionCategory: parseDiscussionCategory(article.discussionCategory),
-    title: parseNonEmptyString(article.title),
+    ...parseDiscussionArticleTitle(
+      parseNonEmptyString(article.title),
+      article.discussionNumber,
+    ),
     description: parseNonEmptyString(article.description),
     pubDate: parseDate(article.pubDate),
     updatedDate:
@@ -166,8 +172,27 @@ export const getCachedDiscussionArticles = async (
 ) => readArticles(directory, await readArticleIds(directory));
 
 // Cache writing
+const createCachedArticle = (
+  article: DiscussionArticle,
+): CachedDiscussionArticle => ({
+  id: article.id,
+  discussionNumber: article.discussionNumber,
+  discussionCategory: article.discussionCategory,
+  title: article.title,
+  description: article.description,
+  pubDate: article.pubDate.toISOString(),
+  ...(article.updatedDate
+    ? { updatedDate: article.updatedDate.toISOString() }
+    : {}),
+  category: article.category,
+  body: article.body,
+});
+
 const writeArticle = (directory: string, article: DiscussionArticle) =>
-  writeJson(join(directory, article.id + ".json"), article);
+  writeJson(
+    join(directory, article.id + ".json"),
+    createCachedArticle(article),
+  );
 
 // index 更新後にだけ実行する。
 const removeStaleArticles = async (

--- a/src/domain/discussionArticle.test.ts
+++ b/src/domain/discussionArticle.test.ts
@@ -67,6 +67,8 @@ describe("createDiscussionArticle", () => {
         name: "Articles",
       },
       title: "Discussion の記事",
+      plainTitle: "Discussion の記事",
+      titleParts: [{ type: "text", value: "Discussion の記事" }],
       description: "記事の概要です。",
       pubDate: new Date("2026-08-25T00:00:00Z"),
       updatedDate: new Date("2026-08-25T01:00:00Z"),
@@ -81,6 +83,22 @@ describe("createDiscussionArticle", () => {
     ).toMatchObject({ updatedDate: undefined });
   });
 
+  it("タイトルのインラインコードを表示用の部分とプレーンテキストへ分ける", () => {
+    expect(
+      createDiscussionArticle(
+        createSource({ title: "Astro の `getStaticPaths` を使う" }),
+      ),
+    ).toMatchObject({
+      title: "Astro の `getStaticPaths` を使う",
+      plainTitle: "Astro の getStaticPaths を使う",
+      titleParts: [
+        { type: "text", value: "Astro の " },
+        { type: "code", value: "getStaticPaths" },
+        { type: "text", value: " を使う" },
+      ],
+    });
+  });
+
   it.each([
     [
       "テンプレートの見出しが不足している",
@@ -91,6 +109,16 @@ describe("createDiscussionArticle", () => {
       "タイトルが空",
       { title: " " },
       "Discussion #100 のタイトルは空にできません。",
+    ],
+    [
+      "タイトルのインラインコードが閉じられていない",
+      { title: "`getStaticPaths を使う" },
+      "Discussion #100 のタイトルのインラインコードを閉じてください。",
+    ],
+    [
+      "タイトルのインラインコードが空",
+      { title: "`` を使う" },
+      "Discussion #100 のタイトルのインラインコードは空にできません。",
     ],
     [
       "概要が空",

--- a/src/domain/discussionArticle.ts
+++ b/src/domain/discussionArticle.ts
@@ -20,11 +20,24 @@ export interface DiscussionArticle {
   readonly discussionNumber: number;
   readonly discussionCategory: DiscussionArticleSource["discussionCategory"];
   readonly title: string;
+  readonly plainTitle: string;
+  readonly titleParts: readonly DiscussionArticleTitlePart[];
   readonly description: string;
   readonly pubDate: Date;
   readonly updatedDate?: Date;
   readonly category: NoteCategory;
   readonly body: string;
+}
+
+export interface DiscussionArticleTitlePart {
+  readonly type: "text" | "code";
+  readonly value: string;
+}
+
+export interface ParsedDiscussionArticleTitle {
+  readonly title: string;
+  readonly plainTitle: string;
+  readonly titleParts: readonly DiscussionArticleTitlePart[];
 }
 
 interface ArticleSections {
@@ -92,14 +105,42 @@ const parseArticleSections = (
   };
 };
 
-const parseTitle = (title: string, number: number) => {
+/** Notes タイトルのインラインコードだけを解析し、表示・SEO 用の値を生成する。 */
+export const parseDiscussionArticleTitle = (
+  title: string,
+  number: number,
+): ParsedDiscussionArticleTitle => {
   const parsedTitle = title.trim();
 
   if (!parsedTitle) {
     throw new Error(`Discussion #${number} のタイトルは空にできません。`);
   }
 
-  return parsedTitle;
+  const values = parsedTitle.split("`");
+
+  if (values.length % 2 === 0) {
+    throw new Error(
+      `Discussion #${number} のタイトルのインラインコードを閉じてください。`,
+    );
+  }
+
+  const titleParts = values.flatMap((value, index) => {
+    const type = index % 2 === 0 ? "text" : "code";
+
+    if (!value && type === "code") {
+      throw new Error(
+        `Discussion #${number} のタイトルのインラインコードは空にできません。`,
+      );
+    }
+
+    return value ? [{ type, value }] : [];
+  });
+
+  return {
+    title: parsedTitle,
+    plainTitle: titleParts.map((part) => part.value).join(""),
+    titleParts,
+  };
 };
 
 const parseDescription = (description: string, number: number) => {
@@ -147,7 +188,7 @@ export const createDiscussionArticle = ({
   lastEditedAt,
 }: DiscussionArticleSource): DiscussionArticle => {
   const sections = parseArticleSections(sourceBody, number);
-  const parsedTitle = parseTitle(title, number);
+  const parsedTitle = parseDiscussionArticleTitle(title, number);
   const description = parseDescription(sections.description, number);
   const slug = parseSlug(sections.slug, number);
   const category = parseCategory(sections.category, number);
@@ -161,7 +202,7 @@ export const createDiscussionArticle = ({
     id: slug,
     discussionNumber: number,
     discussionCategory,
-    title: parsedTitle,
+    ...parsedTitle,
     description,
     pubDate,
     updatedDate,

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -1,5 +1,6 @@
 ---
 import NoteMeta from "../components/NoteMeta.astro";
+import DiscussionArticleTitle from "../components/DiscussionArticleTitle.astro";
 import { getDiscussionArticles } from "../data/discussionArticles";
 import { site } from "../config/site";
 import Layout from "../layouts/Layout.astro";
@@ -32,7 +33,7 @@ const publishedNotes = await getDiscussionArticles();
                   class="notes__link"
                   href={`${import.meta.env.BASE_URL}notes/${note.id}/`}
                 >
-                  {note.title}
+                  <DiscussionArticleTitle parts={note.titleParts} />
                 </a>
               </h2>
 

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { noteCategoryOgps } from "../../config/noteCategoryOgps";
 import { site } from "../../config/site";
+import DiscussionArticleTitle from "../../components/DiscussionArticleTitle.astro";
 import GiscusComments from "../../components/GiscusComments.astro";
 import NoteMeta from "../../components/NoteMeta.astro";
 import {
@@ -27,7 +28,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
 ---
 
 <Layout
-  title={note.title + " | " + site.name}
+  title={note.plainTitle + " | " + site.name}
   description={note.description}
   ogImage={ogImage}
   ogImageAlt={ogImageAlt}
@@ -45,7 +46,9 @@ const ogImageAlt = categoryOgp?.imageAlt;
         showDateLabel
         showUpdatedDate
       />
-      <h1 class="note__title">{note.title}</h1>
+      <h1 class="note__title">
+        <DiscussionArticleTitle parts={note.titleParts} />
+      </h1>
       <p class="note__description">{note.description}</p>
     </header>
 


### PR DESCRIPTION
## 関連 Issue

Closes #71

## 変更内容

- Notes タイトル内のインラインコードを解析・検証し、一覧と記事詳細で表示
- HTML title と OGP タイトルには装飾記法を除いたプレーンテキストを使用
- タイトル内コードの表示を共通コンポーネントに集約し、控えめなアクセント色を適用
- ローカルキャッシュでは派生値を保存せず、読込時に再生成
- インラインコード、不正記法、キャッシュ往復のテストを追加

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- Notes 一覧・記事詳細でタイトル内コードの表示を確認
- HTML title / OGP タイトルにバッククォートが含まれないことを確認

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認