### PR TITLE
fix: Notes のモバイル本文レイアウトを整える

### DIFF
--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -171,7 +171,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
 
 <style lang="scss">
   .note {
-    max-width: 50rem;
+    max-width: 56rem;
     margin-inline: auto;
   }
 
@@ -288,6 +288,7 @@ const ogImageAlt = categoryOgp?.imageAlt;
     font-size: 0.9375rem;
     border-spacing: 0;
     border-collapse: separate;
+    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
   }
@@ -431,9 +432,12 @@ const ogImageAlt = categoryOgp?.imageAlt;
     border-top: 1px solid var(--color-border);
   }
 
-  @media (width <= 30rem) {
+  @media (width <= 40rem) {
     .note__content {
-      padding: var(--space-lg);
+      padding: 0;
+      background: transparent;
+      border: 0;
+      border-radius: 0;
     }
   }
 </style>

--- a/src/styles/foundation/_base.scss
+++ b/src/styles/foundation/_base.scss
@@ -11,6 +11,9 @@ body {
   line-height: 1.7;
   color: var(--color-text);
   background: var(--color-background);
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 h1,


### PR DESCRIPTION
## 関連 Issue

Closes #77

## 変更内容

- モバイル幅（40rem 以下）で Notes 本文の内側余白、枠線、角丸を外し、本文領域を広げる
- モバイルでは本文背景を透明にし、テーブルだけ白背景を維持する
- Notes 記事の最大幅を 56rem に広げる
- iOS での意図しない文字サイズ調整を抑制する

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認