### PR TITLE
feat: Notes に前後記事ナビゲーションを追加

### DIFF
--- a/src/components/NoteArticleNavigation.astro
+++ b/src/components/NoteArticleNavigation.astro
@@ -1,0 +1,146 @@
+---
+import DiscussionArticleTitle from "./DiscussionArticleTitle.astro";
+import type { DiscussionArticle } from "../domain/discussionArticle";
+
+type NoteArticleNavigationArticle = Pick<
+  DiscussionArticle,
+  "id" | "titleParts"
+>;
+
+interface Props {
+  readonly previousArticle?: NoteArticleNavigationArticle;
+  readonly nextArticle?: NoteArticleNavigationArticle;
+}
+
+const { previousArticle, nextArticle } = Astro.props;
+---
+
+{
+  (previousArticle || nextArticle) && (
+    <nav class="note__navigation" aria-label="前後の記事">
+      {previousArticle && (
+        <a
+          class="note__navigation-link"
+          href={`${import.meta.env.BASE_URL}notes/${previousArticle.id}/`}
+        >
+          <span class="note__navigation-direction">
+            <span class="note__navigation-arrow" aria-hidden="true">
+              ←
+            </span>
+            前の記事
+          </span>
+          <span class="note__navigation-title">
+            <DiscussionArticleTitle parts={previousArticle.titleParts} />
+          </span>
+        </a>
+      )}
+      {nextArticle && (
+        <a
+          class="note__navigation-link note__navigation-link--next"
+          href={`${import.meta.env.BASE_URL}notes/${nextArticle.id}/`}
+        >
+          <span class="note__navigation-direction">
+            次の記事
+            <span class="note__navigation-arrow" aria-hidden="true">
+              →
+            </span>
+          </span>
+          <span class="note__navigation-title">
+            <DiscussionArticleTitle parts={nextArticle.titleParts} />
+          </span>
+        </a>
+      )}
+    </nav>
+  )
+}
+
+<style lang="scss">
+  .note__navigation {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-md);
+    padding-top: var(--space-md);
+    margin-top: var(--space-2xl);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .note__navigation-link {
+    display: grid;
+    width: fit-content;
+    min-width: 0;
+    max-width: 100%;
+    min-height: 2.75rem;
+    padding-block: var(--space-xs);
+    padding-inline: var(--space-md);
+    color: var(--color-text);
+    text-align: left;
+
+    &:hover {
+      .note__navigation-title {
+        color: var(--color-accent-strong);
+        text-decoration-color: var(--color-accent-strong);
+      }
+    }
+  }
+
+  .note__navigation-link--next {
+    grid-column: 2;
+    justify-self: end;
+    text-align: right;
+  }
+
+  .note__navigation-direction {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--color-accent-strong);
+  }
+
+  .note__navigation-title {
+    display: -webkit-box;
+    min-width: 0;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+    text-decoration-line: underline;
+    text-decoration-color: transparent;
+    transition:
+      color 160ms ease,
+      text-decoration-color 160ms ease;
+    -webkit-box-orient: vertical;
+  }
+
+  @media (width <= 40rem) {
+    .note__navigation-arrow {
+      display: none;
+    }
+
+    .note__navigation {
+      grid-template-columns: 1fr;
+      gap: var(--space-sm);
+    }
+
+    .note__navigation-link {
+      grid-column: 1;
+      justify-self: stretch;
+      width: 100%;
+      padding: var(--space-sm) var(--space-md);
+      text-align: left;
+      background: transparent;
+      border: 1px solid var(--color-border);
+    }
+
+    .note__navigation-link:hover,
+    .note__navigation-link:active {
+      color: var(--color-accent-strong);
+      background: transparent;
+      border-color: var(--color-accent-strong);
+    }
+
+    .note__navigation-title {
+      -webkit-line-clamp: 3;
+    }
+  }
+</style>

--- a/src/domain/discussionArticleNavigation.test.ts
+++ b/src/domain/discussionArticleNavigation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { DiscussionArticle } from "./discussionArticle";
+
+import {
+  createDiscussionArticleNavigation,
+  sortDiscussionArticles,
+} from "./discussionArticleNavigation";
+
+const createArticle = (
+  id: string,
+  pubDate: string,
+  discussionNumber: number,
+): DiscussionArticle => ({
+  id,
+  discussionNumber,
+  discussionCategory: { id: "articles-category-id", name: "Articles" },
+  title: id,
+  plainTitle: id,
+  titleParts: [{ type: "text", value: id }],
+  description: "記事の概要です。",
+  pubDate: new Date(`${pubDate}T00:00:00Z`),
+  category: "tech",
+  body: "本文です。",
+});
+
+describe("sortDiscussionArticles", () => {
+  it("公開日と Discussion 番号の降順で、元の配列を変更せずに記事を返す", () => {
+    const oldest = createArticle("oldest", "2026-08-25", 1);
+    const lowerNumber = createArticle("lower-number", "2026-08-26", 2);
+    const higherNumber = createArticle("higher-number", "2026-08-26", 3);
+    const articles = [lowerNumber, oldest, higherNumber];
+
+    expect(sortDiscussionArticles(articles)).toEqual([
+      higherNumber,
+      lowerNumber,
+      oldest,
+    ]);
+    expect(articles).toEqual([lowerNumber, oldest, higherNumber]);
+  });
+});
+
+describe("createDiscussionArticleNavigation", () => {
+  it("先頭・中間・末尾の前後記事を返す", () => {
+    const oldest = createArticle("oldest", "2026-08-25", 1);
+    const middle = createArticle("middle", "2026-08-26", 2);
+    const newest = createArticle("newest", "2026-08-27", 3);
+    const navigationByArticleId = new Map(
+      createDiscussionArticleNavigation([middle, oldest, newest]).map(
+        (navigation) => [navigation.article.id, navigation],
+      ),
+    );
+
+    expect(navigationByArticleId.get(newest.id)).toEqual({
+      article: newest,
+      nextArticle: middle,
+    });
+    expect(navigationByArticleId.get(middle.id)).toEqual({
+      article: middle,
+      previousArticle: newest,
+      nextArticle: oldest,
+    });
+    expect(navigationByArticleId.get(oldest.id)).toEqual({
+      article: oldest,
+      previousArticle: middle,
+    });
+  });
+
+  it("記事が1件だけの場合は前後記事を設定しない", () => {
+    const article = createArticle("only", "2026-08-26", 1);
+
+    expect(createDiscussionArticleNavigation([article])).toEqual([{ article }]);
+  });
+});

--- a/src/domain/discussionArticleNavigation.ts
+++ b/src/domain/discussionArticleNavigation.ts
@@ -1,0 +1,30 @@
+import type { DiscussionArticle } from "./discussionArticle";
+
+export interface DiscussionArticleNavigation {
+  readonly article: DiscussionArticle;
+  readonly previousArticle?: DiscussionArticle;
+  readonly nextArticle?: DiscussionArticle;
+}
+
+/** 公開日、同日の場合は Discussion 番号の降順で記事を並べ替える。 */
+export const sortDiscussionArticles = (
+  articles: readonly DiscussionArticle[],
+): readonly DiscussionArticle[] =>
+  articles.toSorted(
+    (a, b) =>
+      b.pubDate.valueOf() - a.pubDate.valueOf() ||
+      b.discussionNumber - a.discussionNumber,
+  );
+
+/** 公開順の記事と前後関係を返す。 */
+export const createDiscussionArticleNavigation = (
+  articles: readonly DiscussionArticle[],
+): readonly DiscussionArticleNavigation[] => {
+  const orderedArticles = sortDiscussionArticles(articles);
+
+  return orderedArticles.map((article, index) => ({
+    article,
+    previousArticle: orderedArticles[index - 1],
+    nextArticle: orderedArticles[index + 1],
+  }));
+};

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -2,10 +2,11 @@
 import NoteMeta from "../components/NoteMeta.astro";
 import DiscussionArticleTitle from "../components/DiscussionArticleTitle.astro";
 import { getDiscussionArticles } from "../data/discussionArticles";
+import { sortDiscussionArticles } from "../domain/discussionArticleNavigation";
 import { site } from "../config/site";
 import Layout from "../layouts/Layout.astro";
 
-const publishedNotes = await getDiscussionArticles();
+const publishedNotes = sortDiscussionArticles(await getDiscussionArticles());
 ---
 
 <Layout

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -3,24 +3,33 @@ import { noteCategoryOgps } from "../../config/noteCategoryOgps";
 import { site } from "../../config/site";
 import DiscussionArticleTitle from "../../components/DiscussionArticleTitle.astro";
 import GiscusComments from "../../components/GiscusComments.astro";
+import NoteArticleNavigation from "../../components/NoteArticleNavigation.astro";
 import NoteMeta from "../../components/NoteMeta.astro";
 import {
   getDiscussionArticles,
   renderDiscussionArticleBody,
 } from "../../data/discussionArticles";
-import type { DiscussionArticle } from "../../domain/discussionArticle";
+import {
+  createDiscussionArticleNavigation,
+  type DiscussionArticleNavigation,
+} from "../../domain/discussionArticleNavigation";
 import Layout from "../../layouts/Layout.astro";
 
 export async function getStaticPaths() {
-  const notes = await getDiscussionArticles();
+  const notes = createDiscussionArticleNavigation(
+    await getDiscussionArticles(),
+  );
 
-  return notes.map((note) => ({
-    params: { slug: note.id },
-    props: { note },
+  return notes.map((navigation) => ({
+    params: { slug: navigation.article.id },
+    props: { navigation },
   }));
 }
 
-const { note } = Astro.props as { readonly note: DiscussionArticle };
+const { navigation } = Astro.props as {
+  readonly navigation: DiscussionArticleNavigation;
+};
+const { article: note } = navigation;
 const discussionArticleHtml = await renderDiscussionArticleBody(note);
 const categoryOgp = noteCategoryOgps[note.category];
 const ogImage = categoryOgp.image;
@@ -56,6 +65,11 @@ const ogImageAlt = categoryOgp.imageAlt;
       class="note__content"
       data-note-code-blocks
       set:html={discussionArticleHtml}
+    />
+
+    <NoteArticleNavigation
+      previousArticle={navigation.previousArticle}
+      nextArticle={navigation.nextArticle}
     />
 
     <script>


### PR DESCRIPTION
## 関連 Issue

Closes #74

## 変更内容

- Notes を公開日・Discussion 番号の降順で並べ、前後記事の関係を生成
- 記事詳細に前後記事ナビゲーションを追加
- PC・モバイルそれぞれに合わせたリンク表示、タイトル省略、キーボードフォーカスを実装
- 前後記事ナビゲーションを専用コンポーネントへ分離

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認