### PR TITLE
feat: Notes 記事詳細に関連記事を表示

### DIFF
--- a/src/components/NoteRelatedArticles.astro
+++ b/src/components/NoteRelatedArticles.astro
@@ -1,0 +1,106 @@
+---
+import DiscussionArticleTitle from "./DiscussionArticleTitle.astro";
+import type { DiscussionArticle } from "../domain/discussionArticle";
+
+type NoteRelatedArticlesArticle = Pick<
+  DiscussionArticle,
+  "id" | "pubDate" | "titleParts"
+>;
+
+interface Props {
+  readonly relatedArticles: readonly NoteRelatedArticlesArticle[];
+}
+
+const { relatedArticles } = Astro.props as Props;
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+---
+
+{
+  relatedArticles.length > 0 && (
+    <section
+      class="note-related-articles"
+      aria-labelledby="related-articles-title"
+    >
+      <h2 id="related-articles-title" class="note-related-articles__title">
+        関連記事
+      </h2>
+
+      <ul class="note-related-articles__list" role="list">
+        {relatedArticles.map((article) => (
+          <li class="note-related-articles__item">
+            <time
+              class="note-related-articles__date"
+              datetime={article.pubDate.toISOString()}
+            >
+              {dateFormatter.format(article.pubDate)}
+            </time>
+            <a
+              class="note-related-articles__link"
+              href={`${import.meta.env.BASE_URL}notes/${article.id}/`}
+            >
+              <DiscussionArticleTitle parts={article.titleParts} />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+<style lang="scss">
+  .note-related-articles {
+    padding-top: var(--space-md);
+    margin-top: var(--space-2xl);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .note-related-articles__title {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.4;
+  }
+
+  .note-related-articles__list {
+    padding: 0;
+    margin: var(--space-sm) 0 0;
+    list-style: none;
+  }
+
+  .note-related-articles__item {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: var(--space-sm);
+    align-items: baseline;
+    padding: var(--space-2xs) 0;
+    font-size: 0.875rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .note-related-articles__date {
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+
+  .note-related-articles__link {
+    min-width: 0;
+    color: var(--color-text);
+    overflow-wrap: anywhere;
+    text-decoration-line: underline;
+    text-underline-offset: 0.18em;
+    transition: color 160ms ease;
+
+    &:is(:hover, :focus-visible) {
+      color: var(--color-accent-strong);
+    }
+  }
+
+  @media (width <= 40rem) {
+    .note-related-articles__item {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/domain/discussionArticleNavigation.test.ts
+++ b/src/domain/discussionArticleNavigation.test.ts
@@ -54,21 +54,96 @@ describe("createDiscussionArticleNavigation", () => {
     expect(navigationByArticleId.get(newest.id)).toEqual({
       article: newest,
       nextArticle: middle,
+      relatedArticles: [middle, oldest],
     });
     expect(navigationByArticleId.get(middle.id)).toEqual({
       article: middle,
       previousArticle: newest,
       nextArticle: oldest,
+      relatedArticles: [newest, oldest],
     });
     expect(navigationByArticleId.get(oldest.id)).toEqual({
       article: oldest,
       previousArticle: middle,
+      relatedArticles: [newest, middle],
     });
   });
 
   it("記事が1件だけの場合は前後記事を設定しない", () => {
     const article = createArticle("only", "2026-08-26", 1);
 
-    expect(createDiscussionArticleNavigation([article])).toEqual([{ article }]);
+    expect(createDiscussionArticleNavigation([article])).toEqual([
+      { article, relatedArticles: [] },
+    ]);
+  });
+
+  it("現在の記事と異なる Notes カテゴリの記事を関連記事から除外する", () => {
+    const current = createArticle("current", "2026-08-26", 1);
+    const sameCategory = createArticle("same-category", "2026-08-27", 2);
+    const otherCategory = {
+      ...createArticle("other-category", "2026-08-28", 3),
+      category: "note" as const,
+    };
+
+    const navigation = createDiscussionArticleNavigation([
+      current,
+      sameCategory,
+      otherCategory,
+    ]).find(({ article }) => article.id === current.id);
+
+    expect(navigation?.relatedArticles).toEqual([sameCategory]);
+  });
+
+  it("同じカテゴリの候補は公開順で最大3件返す", () => {
+    const current = createArticle("current", "2026-08-20", 1);
+    const oldest = createArticle("oldest", "2026-08-21", 2);
+    const lowerNumber = createArticle("lower-number", "2026-08-23", 3);
+    const higherNumber = createArticle("higher-number", "2026-08-23", 4);
+    const newest = createArticle("newest", "2026-08-24", 5);
+
+    const navigation = createDiscussionArticleNavigation([
+      current,
+      oldest,
+      lowerNumber,
+      higherNumber,
+      newest,
+    ]).find(({ article }) => article.id === current.id);
+
+    expect(navigation?.relatedArticles).toEqual([
+      newest,
+      higherNumber,
+      lowerNumber,
+    ]);
+  });
+
+  it("同じカテゴリの候補が1件または2件の場合は存在する記事だけ返す", () => {
+    const current = createArticle("current", "2026-08-20", 1);
+    const one = createArticle("one", "2026-08-21", 2);
+    const two = createArticle("two", "2026-08-22", 3);
+
+    expect(
+      createDiscussionArticleNavigation([current, one]).find(
+        ({ article }) => article.id === current.id,
+      )?.relatedArticles,
+    ).toEqual([one]);
+    expect(
+      createDiscussionArticleNavigation([current, one, two]).find(
+        ({ article }) => article.id === current.id,
+      )?.relatedArticles,
+    ).toEqual([two, one]);
+  });
+
+  it("同じカテゴリの候補がない場合は空配列を返す", () => {
+    const current = createArticle("current", "2026-08-26", 1);
+    const otherCategory = {
+      ...createArticle("other-category", "2026-08-27", 2),
+      category: "devlog" as const,
+    };
+
+    expect(
+      createDiscussionArticleNavigation([current, otherCategory]).find(
+        ({ article }) => article.id === current.id,
+      )?.relatedArticles,
+    ).toEqual([]);
   });
 });

--- a/src/domain/discussionArticleNavigation.ts
+++ b/src/domain/discussionArticleNavigation.ts
@@ -4,6 +4,7 @@ export interface DiscussionArticleNavigation {
   readonly article: DiscussionArticle;
   readonly previousArticle?: DiscussionArticle;
   readonly nextArticle?: DiscussionArticle;
+  readonly relatedArticles: readonly DiscussionArticle[];
 }
 
 /** 公開日、同日の場合は Discussion 番号の降順で記事を並べ替える。 */
@@ -26,5 +27,12 @@ export const createDiscussionArticleNavigation = (
     article,
     previousArticle: orderedArticles[index - 1],
     nextArticle: orderedArticles[index + 1],
+    relatedArticles: orderedArticles
+      .filter(
+        (candidate) =>
+          candidate.discussionNumber !== article.discussionNumber &&
+          candidate.category === article.category,
+      )
+      .slice(0, 3),
   }));
 };

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -4,6 +4,7 @@ import { site } from "../../config/site";
 import DiscussionArticleTitle from "../../components/DiscussionArticleTitle.astro";
 import GiscusComments from "../../components/GiscusComments.astro";
 import NoteArticleNavigation from "../../components/NoteArticleNavigation.astro";
+import NoteRelatedArticles from "../../components/NoteRelatedArticles.astro";
 import NoteMeta from "../../components/NoteMeta.astro";
 import {
   getDiscussionArticles,
@@ -71,6 +72,8 @@ const ogImageAlt = categoryOgp.imageAlt;
       previousArticle={navigation.previousArticle}
       nextArticle={navigation.nextArticle}
     />
+
+    <NoteRelatedArticles relatedArticles={navigation.relatedArticles} />
 
     <script>
       // Code block enhancements


### PR DESCRIPTION
## 関連 Issue

Closes #80

## 変更内容

- Notes 記事詳細に、同じカテゴリの関連記事を最大3件表示する `NoteRelatedArticles` を追加
- 公開日・Discussion 番号による既存の公開順を利用し、現在の記事と異なるカテゴリの記事を除外
- 前後記事ナビゲーションの後、コメント欄の前に関連記事を配置
- 関連記事の公開日、インラインコードを含むタイトル、ベースパス対応リンク、リスト構造、キーボードフォーカス表示を実装

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認