### PR TITLE
feat: Notes のカテゴリ別一覧ページを追加

### DIFF
--- a/src/components/NoteList.astro
+++ b/src/components/NoteList.astro
@@ -1,0 +1,82 @@
+---
+import type { DiscussionArticle } from "../domain/discussionArticle";
+import DiscussionArticleTitle from "./DiscussionArticleTitle.astro";
+import NoteMeta from "./NoteMeta.astro";
+
+type NoteListArticle = Pick<
+  DiscussionArticle,
+  "id" | "category" | "pubDate" | "titleParts" | "description"
+>;
+
+interface Props {
+  articles: readonly NoteListArticle[];
+}
+
+const { articles } = Astro.props as Props;
+---
+
+<ul class="note-list">
+  {
+    articles.map((note) => (
+      <li class="note-list__item">
+        <article class="note-list__article">
+          <NoteMeta category={note.category} pubDate={note.pubDate} />
+
+          <h2 class="note-list__title">
+            <a
+              class="note-list__link"
+              href={`${import.meta.env.BASE_URL}notes/${note.id}/`}
+            >
+              <DiscussionArticleTitle parts={note.titleParts} />
+            </a>
+          </h2>
+
+          <p class="note-list__description">{note.description}</p>
+        </article>
+      </li>
+    ))
+  }
+</ul>
+
+<style lang="scss">
+  .note-list {
+    display: grid;
+    gap: var(--space-md);
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .note-list__article {
+    padding: var(--space-lg);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 0.25rem solid var(--color-mustard);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    transition:
+      border-color 160ms ease,
+      transform 160ms ease;
+
+    &:hover,
+    &:focus-within {
+      border-left-color: var(--color-accent-strong);
+      transform: translateY(-0.125rem);
+    }
+  }
+
+  .note-list__title {
+    margin: 0;
+    font-size: clamp(1.25rem, 3vw, 1.5rem);
+    line-height: 1.4;
+  }
+
+  .note-list__link {
+    color: var(--color-text);
+  }
+
+  .note-list__description {
+    margin: var(--space-sm) 0 0;
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/components/NoteMeta.astro
+++ b/src/components/NoteMeta.astro
@@ -25,7 +25,12 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
 ---
 
 <p class="note-meta">
-  <span class="note-meta__category">{noteCategories[category].label}</span>
+  <a
+    class="note-meta__category"
+    href={`${import.meta.env.BASE_URL}notes/category/${category}/`}
+  >
+    {noteCategories[category].label}
+  </a>
 
   <time datetime={pubDate.toISOString()}>
     {showDateLabel ? "公開: " : ""}{dateFormatter.format(pubDate)}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -5,6 +5,16 @@ import {
 
 const rawChangelogEntries = [
   {
+    date: "2026-08-31",
+    title: "Notes のカテゴリ別一覧を追加",
+    description:
+      "Notes のカテゴリから、同じカテゴリの記事をまとめて探せるようになりました。",
+    link: {
+      kind: "internal",
+      path: "notes/",
+    },
+  },
+  {
     date: "2026-08-24",
     title: "アクセス解析を追加",
     description:

--- a/src/domain/discussionArticleCategory.test.ts
+++ b/src/domain/discussionArticleCategory.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { DiscussionArticle } from "./discussionArticle";
+import { createDiscussionArticleCategoryPages } from "./discussionArticleCategory";
+
+const createArticle = (
+  id: string,
+  category: DiscussionArticle["category"],
+  pubDate: string,
+  discussionNumber: number,
+): DiscussionArticle => ({
+  id,
+  discussionNumber,
+  discussionCategory: { id: "articles-category-id", name: "Articles" },
+  title: id,
+  plainTitle: id,
+  titleParts: [{ type: "text", value: id }],
+  description: "記事の概要です。",
+  pubDate: new Date(`${pubDate}T00:00:00Z`),
+  category,
+  body: "本文です。",
+});
+
+describe("createDiscussionArticleCategoryPages", () => {
+  it("カテゴリ定義順に記事を分類する", () => {
+    const tech = createArticle("tech", "tech", "2026-08-25", 1);
+    const note = createArticle("note", "note", "2026-08-26", 2);
+    const devlog = createArticle("devlog", "devlog", "2026-08-27", 3);
+
+    expect(createDiscussionArticleCategoryPages([note, devlog, tech])).toEqual([
+      { category: "tech", articles: [tech] },
+      { category: "note", articles: [note] },
+      { category: "devlog", articles: [devlog] },
+    ]);
+  });
+
+  it("各カテゴリの記事を公開日と Discussion 番号の降順に並べる", () => {
+    const oldest = createArticle("oldest", "tech", "2026-08-25", 1);
+    const lowerNumber = createArticle("lower-number", "tech", "2026-08-26", 2);
+    const higherNumber = createArticle(
+      "higher-number",
+      "tech",
+      "2026-08-26",
+      3,
+    );
+
+    expect(
+      createDiscussionArticleCategoryPages([lowerNumber, oldest, higherNumber]),
+    ).toEqual([
+      { category: "tech", articles: [higherNumber, lowerNumber, oldest] },
+    ]);
+  });
+
+  it("記事がないカテゴリを結果から除外する", () => {
+    const note = createArticle("note", "note", "2026-08-26", 1);
+
+    expect(createDiscussionArticleCategoryPages([note])).toEqual([
+      { category: "note", articles: [note] },
+    ]);
+  });
+});

--- a/src/domain/discussionArticleCategory.ts
+++ b/src/domain/discussionArticleCategory.ts
@@ -1,0 +1,25 @@
+import {
+  noteCategoryValues,
+  type NoteCategory,
+} from "../config/noteCategories";
+import type { DiscussionArticle } from "./discussionArticle";
+import { sortDiscussionArticles } from "./discussionArticleNavigation";
+
+export interface DiscussionArticleCategoryPage {
+  readonly category: NoteCategory;
+  readonly articles: readonly DiscussionArticle[];
+}
+
+/** Notes カテゴリの定義順に、公開順の記事一覧を持つカテゴリページを作成する。 */
+export const createDiscussionArticleCategoryPages = (
+  articles: readonly DiscussionArticle[],
+): readonly DiscussionArticleCategoryPage[] =>
+  noteCategoryValues.flatMap((category) => {
+    const categoryArticles = sortDiscussionArticles(
+      articles.filter((article) => article.category === category),
+    );
+
+    return categoryArticles.length
+      ? [{ category, articles: categoryArticles }]
+      : [];
+  });

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -1,6 +1,5 @@
 ---
-import NoteMeta from "../components/NoteMeta.astro";
-import DiscussionArticleTitle from "../components/DiscussionArticleTitle.astro";
+import NoteList from "../components/NoteList.astro";
 import { getDiscussionArticles } from "../data/discussionArticles";
 import { sortDiscussionArticles } from "../domain/discussionArticleNavigation";
 import { site } from "../config/site";
@@ -22,28 +21,7 @@ const publishedNotes = sortDiscussionArticles(await getDiscussionArticles());
       </p>
     </header>
 
-    <ul class="notes__list">
-      {
-        publishedNotes.map((note) => (
-          <li class="notes__item">
-            <article class="notes__article">
-              <NoteMeta category={note.category} pubDate={note.pubDate} />
-
-              <h2 class="notes__title">
-                <a
-                  class="notes__link"
-                  href={`${import.meta.env.BASE_URL}notes/${note.id}/`}
-                >
-                  <DiscussionArticleTitle parts={note.titleParts} />
-                </a>
-              </h2>
-
-              <p class="notes__description">{note.description}</p>
-            </article>
-          </li>
-        ))
-      }
-    </ul>
+    <NoteList articles={publishedNotes} />
   </div>
 </Layout>
 
@@ -51,46 +29,5 @@ const publishedNotes = sortDiscussionArticles(await getDiscussionArticles());
   .notes {
     display: grid;
     gap: var(--space-2xl);
-  }
-
-  .notes__list {
-    display: grid;
-    gap: var(--space-md);
-    padding: 0;
-    margin: 0;
-    list-style: none;
-  }
-
-  .notes__article {
-    padding: var(--space-lg);
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-left: 0.25rem solid var(--color-mustard);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-soft);
-    transition:
-      border-color 160ms ease,
-      transform 160ms ease;
-
-    &:hover,
-    &:focus-within {
-      border-left-color: var(--color-accent-strong);
-      transform: translateY(-0.125rem);
-    }
-  }
-
-  .notes__title {
-    margin: 0;
-    font-size: clamp(1.25rem, 3vw, 1.5rem);
-    line-height: 1.4;
-  }
-
-  .notes__link {
-    color: var(--color-text);
-  }
-
-  .notes__description {
-    margin: var(--space-sm) 0 0;
-    color: var(--color-text-muted);
   }
 </style>

--- a/src/pages/notes/category/[category].astro
+++ b/src/pages/notes/category/[category].astro
@@ -1,0 +1,71 @@
+---
+import type { GetStaticPaths } from "astro";
+import NoteList from "../../../components/NoteList.astro";
+import { noteCategoryOgps } from "../../../config/noteCategoryOgps";
+import { noteCategories } from "../../../config/noteCategories";
+import { site } from "../../../config/site";
+import { getDiscussionArticles } from "../../../data/discussionArticles";
+import {
+  createDiscussionArticleCategoryPages,
+  type DiscussionArticleCategoryPage,
+} from "../../../domain/discussionArticleCategory";
+import Layout from "../../../layouts/Layout.astro";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const categoryPages = createDiscussionArticleCategoryPages(
+    await getDiscussionArticles(),
+  );
+
+  return categoryPages.map((categoryPage) => ({
+    params: { category: categoryPage.category },
+    props: { categoryPage },
+  }));
+};
+
+const { categoryPage } = Astro.props as {
+  readonly categoryPage: DiscussionArticleCategoryPage;
+};
+const { category } = categoryPage;
+const categoryLabel = noteCategories[category].label;
+const categoryOgp = noteCategoryOgps[category];
+---
+
+<Layout
+  title={`${categoryLabel} の Notes | ${site.name}`}
+  description={`${categoryLabel} カテゴリの Notes 一覧です。`}
+  ogImage={categoryOgp.image}
+  ogImageAlt={categoryOgp.imageAlt}
+>
+  <div class="notes-category">
+    <a
+      class="notes-category__back-link"
+      href={`${import.meta.env.BASE_URL}notes/`}
+    >
+      ← Notes 一覧へ戻る
+    </a>
+
+    <header class="page__hero page__hero--narrow">
+      <p class="page__eyebrow">MY NOTES</p>
+      <h1 class="page__title">{categoryLabel}</h1>
+      <p class="page__lead">{categoryLabel} カテゴリの記事一覧です。</p>
+    </header>
+
+    <NoteList articles={categoryPage.articles} />
+  </div>
+</Layout>
+
+<style lang="scss">
+  .notes-category {
+    display: grid;
+    gap: var(--space-2xl);
+  }
+
+  .notes-category__back-link {
+    display: inline-flex;
+    width: fit-content;
+    margin-bottom: calc(-1 * var(--space-lg));
+    font-size: 0.875rem;
+    color: var(--color-link);
+    text-underline-offset: 0.18em;
+  }
+</style>


### PR DESCRIPTION
## 関連 Issue

Closes #75

## 変更内容

- Notes カテゴリごとに記事を分類・公開順に並べるドメイン処理を追加
- 記事があるカテゴリだけを `notes/category/<category>/` として静的生成
- カテゴリ別ページにカテゴリラベル、description、カテゴリ別 OGP、Notes一覧へ戻るリンクを追加
- カテゴリラベルをカテゴリ別一覧へのリンクに変更
- Notes一覧とカテゴリ別一覧で記事リストのマークアップ・スタイルを `NoteList` に共通化
- カテゴリ分類、並び順、空カテゴリ除外の単体テストを追加
- `NoteList` の入力型を表示項目だけに限定し、`getStaticPaths` を `GetStaticPaths` 型で検証

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- カテゴリ別URLがサイトマップに含まれることを確認
- 開発サーバーのHTMLで、Notes一覧・カテゴリ別一覧・記事詳細のカテゴリ導線と戻るリンクを確認

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認（不要）