### PR TITLE
Notes の引用元リンクを整形する

### DIFF
--- a/src/data/discussionArticles.test.ts
+++ b/src/data/discussionArticles.test.ts
@@ -68,6 +68,11 @@ const importArticles = async (responses: readonly Response[]) => {
   return { articles: await import("./discussionArticles"), fetchMock };
 };
 
+const renderArticleBody = async (body: string) => {
+  const { renderDiscussionArticleBody } = await import("./discussionArticles");
+  return renderDiscussionArticleBody({ body });
+};
+
 afterEach(() => {
   vi.doUnmock("./discussionArticlesCache");
   vi.unstubAllEnvs();
@@ -226,11 +231,9 @@ describe("getDiscussionArticles", () => {
 
 describe("renderDiscussionArticleBody", () => {
   it("wraps Markdown tables in a scrollable region", async () => {
-    const { renderDiscussionArticleBody } =
-      await import("./discussionArticles");
-    const html = await renderDiscussionArticleBody({
-      body: "| Name | Value |\n| --- | --- |\n| Long name | Content |",
-    });
+    const html = await renderArticleBody(
+      "| Name | Value |\n| --- | --- |\n| Long name | Content |",
+    );
 
     expect(html).toMatch(/<div class="note__table-scroll"[^>]*>\s*<table>/);
     expect(html).toContain('tabindex="0"');
@@ -241,12 +244,121 @@ describe("renderDiscussionArticleBody", () => {
   });
 
   it("makes the code block scroll region keyboard focusable", async () => {
-    const { renderDiscussionArticleBody } =
-      await import("./discussionArticles");
-    const html = await renderDiscussionArticleBody({
-      body: "```ts\nconst longLine = 'Content';\n```",
-    });
+    const html = await renderArticleBody(
+      "```ts\nconst longLine = 'Content';\n```",
+    );
 
     expect(html).toMatch(/<pre(?![^>]*tabindex)[^>]*>\s*<code tabindex="0">/);
+  });
+
+  it("formats an X post quote source", async () => {
+    const html = await renderArticleBody(
+      "> 引用本文\n>\n> 引用: https://x.com/working_corgi/status/1234567890",
+    );
+
+    expect(html).toContain("<p>引用本文</p>");
+    expect(html).toContain(
+      '<p class="note__quote-source">—\u00a0<a href="https://x.com/working_corgi/status/1234567890">@working_corgi のポスト</a></p>',
+    );
+  });
+
+  it("formats a non-X HTTPS quote source with its hostname", async () => {
+    const html = await renderArticleBody(
+      "> 引用本文\n>\n> 引用: https://example.com/articles/1",
+    );
+
+    expect(html).toContain(
+      '<p class="note__quote-source">—\u00a0<a href="https://example.com/articles/1">example.com のリンク</a></p>',
+    );
+  });
+
+  it("leaves quote sources outside the target format unchanged", async () => {
+    const html = await renderArticleBody(
+      "> 引用: http://example.com\n\n> 通常の引用 https://example.com",
+    );
+
+    expect(html).not.toContain("note__quote-source");
+    expect(html).toContain(
+      '<a href="http://example.com">http://example.com</a>',
+    );
+    expect(html).toContain(
+      '<a href="https://example.com">https://example.com</a>',
+    );
+  });
+
+  it("uses a generic label when an X post URL has no username", async () => {
+    const html = await renderArticleBody(
+      "> 引用本文\n>\n> 引用: https://x.com/status/1234567890",
+    );
+
+    expect(html).toContain(
+      '<p class="note__quote-source">—\u00a0<a href="https://x.com/status/1234567890">Xのポスト</a></p>',
+    );
+  });
+
+  it.each([
+    ["URL側がインラインコード", "> 引用: `https://example.com`"],
+    ["URL側が強調", "> 引用: **https://example.com**"],
+    [
+      "表示 URL と href が異なるリンク",
+      "> 引用: [https://example.com](https://different.example.com)",
+    ],
+  ])("%s の出典候補は変換しない", async (_label, body) => {
+    const html = await renderArticleBody(body);
+
+    expect(html).not.toContain("note__quote-source");
+  });
+
+  it("タイトル付き Markdown リンクは元のリンク情報を保持する", async () => {
+    const html = await renderArticleBody(
+      '> 引用: [https://example.com](https://example.com "出典")',
+    );
+
+    expect(html).not.toContain("note__quote-source");
+    expect(html).toContain(
+      '<a href="https://example.com" title="出典">https://example.com</a>',
+    );
+  });
+
+  it("引用: と URL が別行の場合は変換しない", async () => {
+    const html = await renderArticleBody("> 引用:\n> https://example.com");
+
+    expect(html).not.toContain("note__quote-source");
+  });
+
+  it("https:// で始まらないリンク文字列は変換しない", async () => {
+    const html = await renderArticleBody(
+      "> 引用: [https:example.com](https:example.com)",
+    );
+
+    expect(html).not.toContain("note__quote-source");
+  });
+
+  it.each([
+    ["水平線", "> 引用: https://example.com\n>\n> ---"],
+    ["空のコードブロック", "> 引用: https://example.com\n>\n> ```\n> ```"],
+  ])("出典段落の後ろに %s がある場合は変換しない", async (_label, body) => {
+    const html = await renderArticleBody(body);
+
+    expect(html).not.toContain("note__quote-source");
+  });
+
+  it("X ポスト URL のクエリ、フラグメント、後続パスを許容する", async () => {
+    const html = await renderArticleBody(
+      "> 引用: https://x.com/working_corgi/status/id/extra?source=note#quote",
+    );
+
+    expect(html).toContain(
+      '<a href="https://x.com/working_corgi/status/id/extra?source=note#quote">@working_corgi のポスト</a>',
+    );
+  });
+
+  it.each([
+    ["www.x.com", "https://www.x.com/working_corgi/status/123"],
+    ["twitter.com", "https://twitter.com/working_corgi/status/123"],
+  ])("%s は通常の HTTPS リンクとして扱う", async (hostname, url) => {
+    const html = await renderArticleBody(`> 引用: ${url}`);
+
+    expect(html).toContain(`<a href="${url}">${hostname} のリンク</a>`);
   });
 });

--- a/src/data/discussionArticles.ts
+++ b/src/data/discussionArticles.ts
@@ -40,6 +40,7 @@ interface HtmlNode {
   readonly tagName?: string;
   readonly properties?: Record<string, unknown>;
   readonly children?: HtmlNode[];
+  readonly value?: string;
 }
 
 const repository = { owner: "t-ooshiro0125", name: "workingcorgi" };
@@ -93,8 +94,117 @@ const makeCodeBlockKeyboardScrollable = (node: HtmlNode): HtmlNode => {
   };
 };
 
+interface QuoteSource {
+  readonly href: string;
+  readonly url: URL;
+}
+
+const isText = (node: HtmlNode) => node.type === "text";
+
+const isWhitespaceText = (node: HtmlNode) =>
+  isText(node) && !node.value?.trim();
+
+const findLastMeaningfulChild = (children: HtmlNode[]) =>
+  children.findLast((child) => !isWhitespaceText(child));
+
+const hasOnlyHrefProperty = (properties: Record<string, unknown> | undefined) =>
+  Object.keys(properties ?? {}).length === 1 &&
+  typeof properties?.href === "string";
+
+const parseQuoteSourceParagraph = (node: HtmlNode): QuoteSource | undefined => {
+  if (!isElement(node, "p") || node.children?.length !== 2) {
+    return;
+  }
+
+  const [prefix, link] = node.children;
+
+  if (
+    !isText(prefix) ||
+    !/^引用:[ \t]*$/u.test(prefix.value ?? "") ||
+    !isElement(link, "a") ||
+    link.children?.length !== 1 ||
+    !hasOnlyHrefProperty(link.properties)
+  ) {
+    return;
+  }
+
+  const [linkText] = link.children;
+  const href = link.properties?.href;
+
+  if (
+    !isText(linkText) ||
+    typeof href !== "string" ||
+    href !== linkText.value ||
+    !linkText.value.startsWith("https://")
+  ) {
+    return;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(href);
+  } catch {
+    return;
+  }
+
+  return url.protocol === "https:" ? { href, url } : undefined;
+};
+
+const getQuoteSourceLabel = (sourceUrl: URL) => {
+  if (sourceUrl.hostname !== "x.com") {
+    return `${sourceUrl.hostname} のリンク`;
+  }
+
+  const [, username, resource, postId] = sourceUrl.pathname.split("/");
+
+  return username && resource === "status" && postId
+    ? `@${username} のポスト`
+    : "Xのポスト";
+};
+
+const createQuoteSourceNode = (
+  node: HtmlNode,
+  source: QuoteSource,
+): HtmlNode => ({
+  ...node,
+  properties: {
+    ...node.properties,
+    className: ["note__quote-source"],
+  },
+  children: [
+    { type: "text", value: "—\u00a0" },
+    {
+      type: "element",
+      tagName: "a",
+      properties: { href: source.href },
+      children: [{ type: "text", value: getQuoteSourceLabel(source.url) }],
+    },
+  ],
+});
+
+const formatQuoteSource = (node: HtmlNode): HtmlNode => {
+  if (!isElement(node, "blockquote")) {
+    return node;
+  }
+
+  const lastChild = findLastMeaningfulChild(node.children ?? []);
+  const source = lastChild && parseQuoteSourceParagraph(lastChild);
+
+  if (!lastChild || !source) {
+    return node;
+  }
+
+  return {
+    ...node,
+    children: node.children?.map((child) =>
+      child === lastChild ? createQuoteSourceNode(child, source) : child,
+    ),
+  };
+};
+
 const enhanceNoteHtmlNode = (node: HtmlNode) =>
-  makeCodeBlockKeyboardScrollable(wrapTable(node));
+  formatQuoteSource(makeCodeBlockKeyboardScrollable(wrapTable(node)));
 
 const transformHtmlNodes = (
   children: HtmlNode[],

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -298,6 +298,18 @@ const ogImageAlt = categoryOgp.imageAlt;
     margin-block: 0;
   }
 
+  .note__content :global(blockquote .note__quote-source) {
+    margin-top: var(--space-sm);
+    font-size: 0.875rem;
+    color: color-mix(in srgb, var(--color-text-muted) 95%, var(--color-text));
+    text-align: right;
+  }
+
+  .note__content :global(blockquote .note__quote-source a) {
+    color: inherit;
+    text-decoration-thickness: 0.075em;
+  }
+
   .note__content :global(table) {
     width: 100%;
     min-width: 0;


### PR DESCRIPTION
## 関連 Issue

Closes #90

<!-- `main` へマージすると、Closes #<番号> で指定した Issue が自動的に Close される。 -->

## 変更内容

- blockquote末尾の`引用: https://...`を出典リンクとして整形
- Xポストはユーザー名付き、それ以外はドメイン名付きのラベルを表示
- 出典行をem dash、右揃え、控えめな文字色と下線で本文から区別
- 対象形式と非対象形式のMarkdown変換テストを追加

## 確認内容

- `npm run format:check`
- `npm run lint`
- `npm test`（106件成功）
- `npm run build`（18ページ生成、サイトマップ作成）
- `git diff --cached --check`

## チェックリスト

- [x] 関連 Issue のリンク（該当する場合）
- [x] 変更差分の自己レビュー
- [x] `.env` 等の機密情報が含まれていないこと
- [x] `npm run format:check`、`npm run lint`、`npm test`、`npm run build` を実行
- [x] ブラウザで表示を確認
- [x] 関連ドキュメントの更新要否を確認